### PR TITLE
Revert "android-test-lib adb_join_wifi: uninstall the package"

### DIFF
--- a/automated/lib/android-test-lib
+++ b/automated/lib/android-test-lib
@@ -332,10 +332,5 @@ adb_join_wifi() {
         wget http://testdata.validation.linaro.org/apks/wifi/wifi.apk
         adb install wifi.apk
         adb shell am start -n com.steinwurf.adbjoinwifi/.MainActivity -e ssid "${AP_SSID}" -e password_type WPA -e password "${AP_KEY}"
-
-        # uninstall the packge to avoid effect like reported here:
-        # https://bugs.linaro.org/show_bug.cgi?id=4236
-        sleep 2
-        adb uninstall com.steinwurf.adbjoinwifi
     fi
 }


### PR DESCRIPTION
uninstall that package would cause wifi disconnected

as reported here:
https://projects.linaro.org/browse/LSS-402

This reverts commit 1136333f3659ab251096848444d94ae7e478d31a.