### PR TITLE
android/tradefed: improve reboot variable comparison

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -51,7 +51,7 @@ run:
         # create test use to run the cts/vts tests
         - useradd -m testuser && echo "testuser created successfully"
         - chown testuser:testuser .
-        - if [ "X${TEST_REBOOT_EXPECTED}" = "XTrue" ]; then ./monitor_fastboot.sh & fi
+        - if [ "${TEST_REBOOT_EXPECTED,,}" = "true" ]; then ./monitor_fastboot.sh & fi
         - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}"
         # Upload test log and result files to artifactorial.
         - cp -r ./${TEST_PATH}/results ./output/ || true
@@ -66,4 +66,4 @@ run:
         - userdel testuser -f -r || true
         # When adb device lost, end test job to mark it as 'incomplete'.
         - if ! adb shell echo ok; then error_fatal "adb device $ANDROID_SERIAL lost!"; fi
-        - if [ "X${TEST_REBOOT_EXPECTED}" = "XTrue" ]; then killall monitor_fastboot.sh; fi
+        - if [ "${TEST_REBOOT_EXPECTED,,}" = "true" ]; then killall monitor_fastboot.sh; fi

--- a/automated/android/tradefed/tradefed.yaml
+++ b/automated/android/tradefed/tradefed.yaml
@@ -52,7 +52,7 @@ run:
         # create test use to run the cts/vts tests
         - useradd -m testuser && echo "testuser created successfully"
         - chown testuser:testuser .
-        - if [[ ${TEST_REBOOT_EXPECTED} == "True" ]]; then ./monitor_fastboot.sh & fi
+        - if [ "${TEST_REBOOT_EXPECTED,,}" = "true" ]; then ./monitor_fastboot.sh & fi
         - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}" -j "${JAVA_OPTIONS}"
         # Upload test log and result files to artifactorial.
         - cp -r ./${TEST_PATH}/results ./output/ || true
@@ -67,4 +67,4 @@ run:
         - userdel testuser -f -r || true
         # When adb device lost, end test job to mark it as 'incomplete'.
         - if ! adb shell echo ok; then error_fatal "adb device $ANDROID_SERIAL lost!"; fi
-        - if [[ ${TEST_REBOOT_EXPECTED} == "True" ]]; then killall monitor_fastboot.sh; fi
+        - if [ "${TEST_REBOOT_EXPECTED,,}" = "true" ]; then killall monitor_fastboot.sh; fi


### PR DESCRIPTION
Make sure that comparison is case insensitive to catch any possible
reboot in LAVA. Also align the comparison condition between different
tradefed implementations.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>