### PR TITLE
noninteractive-tradefed: use grep to workaround Bad substitution  problem

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -51,7 +51,7 @@ run:
         # create test use to run the cts/vts tests
         - useradd -m testuser && echo "testuser created successfully"
         - chown testuser:testuser .
-        - if [ "${TEST_REBOOT_EXPECTED,,}" = "true" ]; then ./monitor_fastboot.sh & fi
+        - if echo "${TEST_REBOOT_EXPECTED}" |grep -i "true" ; then ./monitor_fastboot.sh & fi
         - ./monitor_adb.sh &
         - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}"
         # Upload test log and result files to artifactorial.
@@ -67,5 +67,5 @@ run:
         - userdel testuser -f -r || true
         # When adb device lost, end test job to mark it as 'incomplete'.
         - if ! adb shell echo ok; then error_fatal "adb device $ANDROID_SERIAL lost!"; fi
-        - if [ "${TEST_REBOOT_EXPECTED,,}" = "true" ]; then killall monitor_fastboot.sh; fi
+        - if echo "${TEST_REBOOT_EXPECTED}" |grep -i "true" ; then killall monitor_fastboot.sh; fi
         - killall monitor_adb.sh


### PR DESCRIPTION
reported like following:
/lava-610173/1/tests/1_cts-focused2-armeabi-v7a/run.sh: 35: /lava-610173/1/tests/1_cts-focused2-armeabi-v7a/run.sh: Bad substitution

but not sure why this problem only happens for x15 jobs,
jobs for hikey builds could work without problem

Change-Id: I4dbaf0670f82bec69e2146d8cf91974feaf86dc1
Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>