### PR TITLE
LTP: skip LTP dio long running tests on all devices

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -234,3 +234,24 @@ skiplist:
       - all
     tests:
       - ksm01
+
+  - reason: >
+      skip long running LTP dio tests on all devices
+    url: https://projects.linaro.org/browse/KV-171
+    environments: production
+    boards:
+      - all
+    branches:
+      - all
+    tests:
+      - dio10
+      - dio16
+      - dio17
+      - dio20
+      - dio21
+      - dio24
+      - dio25
+      - dio27
+      - dio28
+      - dio29
+      - dio30


### PR DESCRIPTION
From KV-171 investigation LTP dio long running tests have been
identified and skipping those test cases on all devices.

Ref:
https://projects.linaro.org/browse/KV-171

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>