### PR TITLE
sanity-check: improve file type determination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 # https://github.com/koalaman/shellcheck#installing-the-shellcheck-binary
 # php 7.2
 install:
-  - pip install pyyaml pycodestyle
+  - pip install pyyaml pycodestyle python-magic
 
 script:
   - ./sanity-check.sh


### PR DESCRIPTION
* Use libmagic to detect file type so that we don't have to update the
  file for new files without extension.
* Because test plan and lava test job definition yaml file also contain
  'metadata' key, use 'run' key to determine test definition yaml file.
* Skip sanity check on unknown file types.

Signed-off-by: Chase Qi <chase.qi@linaro.org>