### PR TITLE
kselftest: skip kernel crash test case test_tunnel.sh on all devices

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -151,3 +151,12 @@ skiplist:
       - 4.9
     tests:
       - sync_test
+
+  - reason: >
+      LKFT: bpf: test_tunnel.sh: BUG: unable to handle kernel NULL pointer dereference
+    url: https://bugs.linaro.org/show_bug.cgi?id=4307
+    environments: all
+    boards: all
+    branches: all
+    tests:
+      - test_tunnel.sh


### PR DESCRIPTION
Kernel panic while running bpf: test_tunnel.sh on linux -next and mainline
This is been reported upstream and waiting for the fix.
till it get fixed this test case test_tunnel.sh will be skipped on all devices
and all branches

Ref:
https://bugs.linaro.org/show_bug.cgi?id=4307

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>