### PR TITLE
linux/perf: Adding perf test case for LKFT test plan

### DIFF
--- a/automated/linux/perf/perf.sh
+++ b/automated/linux/perf/perf.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+export RESULT_FILE
+SKIP_INSTALL="false"
+# List of test cases
+TEST="record report stat test"
+# PERF version
+PERF_VERSION="$(uname -r | cut -d . -f 1-2)"
+
+usage() {
+    echo "Usage: $0 [-s <true|false>]" 1>&2
+    exit 1
+}
+
+while getopts "s:h" arg; do
+   case "$arg" in
+     s) SKIP_INSTALL="${OPTARG}";;
+     h|*) usage ;;
+   esac
+done
+
+# Run perf record tests
+run_perf_record() {
+    # Test 'perf record'
+    info_msg "Performing perf record test..."
+    TCID="perf_record_test"
+    perf record -e cycles -o perf-lava-test.data ls -a  2>&1 | tee perf-record.log
+    samples=$(grep -ao "[0-9]\\+[ ]\\+samples" perf-record.log| cut -f 1 -d' ')
+    if [ "${samples}" -gt 1 ]; then
+        report_pass "${TCID}"
+    else
+        report_fail "${TCID}"
+    fi
+    rm perf-record.log
+}
+
+# Run perf report tests
+run_perf_report() {
+    # Test 'perf report'
+    info_msg "Performing perf report test..."
+    TCID="perf_report_test"
+    perf report -i perf-lava-test.data 2>&1 | tee perf-report.log
+    pcnt_samples=$(grep -c -e "^[ ]\\+[0-9]\\+.[0-9]\\+%" perf-report.log)
+    if [ "${pcnt_samples}" -gt 1 ]; then
+        report_pass "${TCID}"
+    else
+        report_fail "${TCID}"
+    fi
+    rm perf-report.log perf-lava-test.data
+}
+
+# Run perf stat tests
+run_perf_stat() {
+    # Test 'perf stat'
+    info_msg "Performing perf stat test..."
+    TCID="perf_stat_test"
+    perf stat -e cycles ls -a 2>&1 | tee perf-stat.log
+    cycles=$(grep -o "[0-9,]\\+[ ]\\+cycles" perf-stat.log | sed 's/,//g' | cut -f 1 -d' ')
+    if [ -z "${cycles}" ]; then
+        report_skip "${TCID}"
+    else
+        if [ "${cycles}" -gt 1 ]; then
+            report_pass "${TCID}"
+        else
+            report_fail "${TCID}"
+        fi
+    fi
+    rm perf-stat.log
+}
+
+# Run perf test tests
+run_perf_test() {
+    # Test 'perf test'
+    info_msg "Performing 'perf test'..."
+    perf test -v
+    report_pass "perf_test"
+}
+
+# Test run.
+! check_root && error_msg "This script must be run as root"
+create_out_dir "${OUTPUT}"
+
+info_msg "About to run perf test..."
+info_msg "Output directory: ${OUTPUT}"
+
+if [ "${SKIP_INSTALL}" = "True" ] || [ "${SKIP_INSTALL}" = "true" ]; then
+    info_msg "install perf skipped"
+else
+    dist_name
+    # shellcheck disable=SC2154
+    case "${dist}" in
+      debian|ubuntu)
+	pkgs="linux-perf-${PERF_VERSION}"
+        install_deps "${pkgs}" "${SKIP_INSTALL}"
+        ;;
+      *)
+        warn_msg "Unsupported distribution: package install skipped"
+    esac
+fi
+
+info_msg "check which perf"
+which perf > /dev/null
+exit_on_fail "perf-existence-check"
+
+# List of test cases "record report stat test"
+for tests in ${TEST}; do
+    run_perf_"${tests}"
+done

--- a/automated/linux/perf/perf.yaml
+++ b/automated/linux/perf/perf.yaml
@@ -1,0 +1,30 @@
+metadata:
+    name: perf
+    format: "Lava-Test-Shell Test Definition 1.0"
+    description: "Perf is a profiler tool for Linux and is used to collect and analyze performance and trace data.
+                  This test runs following perf commands: record(record events for later reporting), report(break
+                  down events by process, function, etc), stat(obtain event counts) and test(Run sanity tests)."
+    maintainer:
+        - naresh.kamboju@linaro.org
+        - milosz.wasilewski@linaro.org
+    os:
+        - openembedded
+        - debian
+    scope:
+        - performance
+    devices:
+        - dragonboard410c
+        - hi6220-hikey
+        - juno
+        - x15
+        - x86
+    environment:
+        - lava-test-shell
+params:
+    SKIP_INSTALL: false
+
+run:
+    steps:
+        - cd ./automated/linux/perf/
+        - ./perf.sh -s "${SKIP_INSTALL}"
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Perf is a profiler tool for Linux and is used to collect and analyze
performance and trace data.
This test runs following perf commands:
- record(record events for later reporting)
- report(break down events by process, function, etc)
- stat(obtain event counts)
- test(Run sanity tests)

Upstream link,
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/tools/perf/Documentation/perf.txt

Ref:
Test perf in LKFT
https://projects.linaro.org/browse/KV-195

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>