### PR TITLE
kselftests: fix tar magic

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -146,7 +146,7 @@ else
       # Download and extract kselftest tarball.
       wget http://testdata.validation.linaro.org/tests/kselftest/"${TESTPROG}" -O kselftest.tar.gz
     fi
-    tar xf "kselftest.tar.gz"
+    tar zxf "kselftest.tar.gz"
     # shellcheck disable=SC2164
     cd "kselftest"
 fi


### PR DESCRIPTION
Not all versions of tar automatically detect compressed archives (eg.
BusyBox v1.22.1 version of tar). Hence the [z] option needs to be
specified in order to successfully untar a gunzip archive in these cases.