### PR TITLE
adb_join_wifi: use new non-debugable apk

### DIFF
--- a/automated/lib/android-test-lib
+++ b/automated/lib/android-test-lib
@@ -325,8 +325,11 @@ adb_join_wifi() {
 
     # Try to connect to wifi if found the WIFI AP information
     if [ -n "${AP_SSID}" ] && [ -n "${AP_KEY}" ]; then
-        wget http://testdata.validation.linaro.org/apks/wifi/wifi.apk
-        adb install wifi.apk
+        # source files are here:
+        # https://github.com/steinwurf/adb-join-wifi
+        apk_url="http://testdata.linaro.org/apks/wifi/AdbJoinWifi-nodegbug-OMR1-support.apk"
+        wget ${apk_url} -O wifi.apk
+        adb install -r wifi.apk
         adb shell am start -n com.steinwurf.adbjoinwifi/.MainActivity -e ssid "${AP_SSID}" -e password_type WPA -e password "${AP_KEY}"
     fi
 }


### PR DESCRIPTION
to resolve the problem reported here:
https://bugs.linaro.org/show_bug.cgi?id=4236

as there is a problem to fix the cached apk in lab
as mentioned here[1], we changed to use new file name
to workaround.

[1]: https://projects.linaro.org/browse/LSS-432?focusedCommentId=76245&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-76245

Tested with following jobs:
https://validation.linaro.org/scheduler/job/1909008 -- aosp master builds
https://validation.linaro.org/scheduler/job/1909009 -- lcr pie build
https://validation.linaro.org/scheduler/job/1909010 -- oreo build
https://lkft.validation.linaro.org/scheduler/job/641823 -- lcr pie build on lkft

Change-Id: Ibc51a802117cecfe1d15b288bac9b55f6e0feec4
Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>