### PR TITLE
ART: add few repos in manifest

### DIFF
--- a/automated/android/microbenchmarks/manifest.xml
+++ b/automated/android/microbenchmarks/manifest.xml
@@ -5,12 +5,39 @@
           fetch="https://android-git.linaro.org/git/"
           review="android-review.linaro.org"
           />
+  <default revision="master"
+           remote="linaro-android"
+           sync-j="8" />
 
   <!-- Add ART optimization related projects -->
-  <project path="art" name="platform/art" revision="master" remote="linaro-android"/>
+  <project path="art" name="platform/art" />
 
   <!-- ART test scripts and benchmarks -->
-  <project path="scripts" name="linaro-art/art-build-scripts" revision="master" remote="linaro-android" />
-  <project path="benchmarks" name="linaro/art-testing" revision="master" remote="linaro-android" />
+  <project path="scripts" name="linaro-art/art-build-scripts" />
+  <project path="benchmarks" name="linaro/art-testing" />
+
+  <!-- ART target for running art target tests" -->
+  <project path="device/generic/art" name="device/generic/art" />
+
+  <project path="build/make" name="platform/build" groups="pdk">
+    <copyfile src="core/root.mk" dest="Makefile" />
+    <linkfile src="CleanSpec.mk" dest="build/CleanSpec.mk" />
+    <linkfile src="buildspec.mk.default" dest="build/buildspec.mk.default" />
+    <linkfile src="core" dest="build/core" />
+    <linkfile src="envsetup.sh" dest="build/envsetup.sh" />
+    <linkfile src="target" dest="build/target" />
+    <linkfile src="tools" dest="build/tools" />
+  </project>
+
+  <project path="build/soong" name="platform/build/soong" groups="pdk,tradefed">
+    <linkfile src="root.bp" dest="Android.bp" />
+    <linkfile src="bootstrap.bash" dest="bootstrap.bash" />
+  </project>
+  <project path="build/blueprint" name="platform/build/blueprint" groups="pdk,tradefed" />
+  <project path="prebuilts/go/linux-x86" name="platform/prebuilts/go/linux-x86" groups="linux,pdk,tradefed" clone-depth="1" />
+  <project path="external/golang-protobuf" name="platform/external/golang-protobuf" groups="pdk" />
+  <project path="prebuilts/build-tools" name="platform/prebuilts/build-tools" groups="pdk" clone-depth="1" />
+  <project path="prebuilts/vndk/v28" name="platform/prebuilts/vndk/v28" groups="pdk" clone-depth="1" />
+
 
 </manifest>


### PR DESCRIPTION
To use Google's ART buildbot scripts, we need to at least be able to
source the AOSP environment.

This results in a longer sync, but still reasonable (less than
45s).