### PR TITLE
v4l2: fix results parsing

### DIFF
--- a/automated/linux/v4l2/v4l2-compliance.sh
+++ b/automated/linux/v4l2/v4l2-compliance.sh
@@ -63,4 +63,5 @@ grep -e FAIL -e OK "${LOG_FILE}" | \
       -e 's/:_/ /' \
       -e 's/ OK/ pass/' \
       -e 's/ FAIL/ fail/' \
+      -e 's/\//-/g' \
       >> "${RESULT_FILE}"


### PR DESCRIPTION
Replacing string "/" with "-" for better results format for test case names.

Test case names:
old VIDIOC_G/S_TUNER/ENUM_FREQ_BANDS
new VIDIOC_G-S_TUNER-ENUM_FREQ_BANDS

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>