### PR TITLE
memtester: add existence check

### DIFF
--- a/automated/linux/memtester/memtester.sh
+++ b/automated/linux/memtester/memtester.sh
@@ -52,6 +52,10 @@ parser() {
 
 create_out_dir "${OUTPUT}"
 install
+
+command -v memtester
+exit_on_fail "memtester-existence-check"
+
 for i in $(seq "${ITERATIONS}"); do
     output="${OUTPUT}/memtester-iter$i.txt"
 


### PR DESCRIPTION
Add a failure point if memtester isn't installed in the rootfs

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>
Change-Id: Icc149f03689318b9ca75a67e57b3d5bd298e31db