### PR TITLE
Revert "kselftest: skip kernel crash test case test_tunnel.sh on all …

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -151,12 +151,3 @@ skiplist:
       - 4.9
     tests:
       - sync_test
-
-  - reason: >
-      LKFT: bpf: test_tunnel.sh: BUG: unable to handle kernel NULL pointer dereference
-    url: https://bugs.linaro.org/show_bug.cgi?id=4307
-    environments: all
-    boards: all
-    branches: all
-    tests:
-      - test_tunnel.sh


### PR DESCRIPTION
…devices"

This reverts commit 1b474c9cb3229ccf9fe7c9243b94f5307b4f2d68.
Bug #4307 is been resolved fixed.
Now the fix patch landed into linux-next and mainline.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>