### PR TITLE
kvm-unit-tests: Adding DEVICE parameter for juno-r2

### DIFF
--- a/automated/linux/kvm-unit-tests/kvm-unit-tests.yaml
+++ b/automated/linux/kvm-unit-tests/kvm-unit-tests.yaml
@@ -23,9 +23,11 @@ metadata:
 
 params:
     SKIP_INSTALL: "False"
+    # Device required only for juno-r2
+    DEVICE: ""
 
 run:
     steps:
         - cd ./automated/linux/kvm-unit-tests/
-        - ./kvm-unit-tests.sh -s "${SKIP_INSTALL}"
+        - ./kvm-unit-tests.sh -s "${SKIP_INSTALL}" -d "${DEVICE}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/kvm-unit-tests/setup.sh
+++ b/automated/linux/kvm-unit-tests/setup.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+BIG_CPU_PART="0xd08"
+LIST_BIG_CPUS=""
+
+find_cpu () {
+    PART=$1
+
+    while read -r LINE; do
+        IFS=':'
+        # shellcheck disable=SC2039
+        # shellcheck disable=SC2206
+        TOKENS=(${LINE})
+        if [ "${LINE#'processor'}" != "${LINE}" ]; then
+	    CPU="${TOKENS[1]##' '}"
+        elif [ "${LINE#'CPU part'}" != "${LINE}" ]; then
+            GET_PART="${TOKENS[1]##' '}"
+            if [ "${PART}" = "${GET_PART}" ]; then
+                printf "%s ${CPU}"
+	    fi
+	fi
+    done < /proc/cpuinfo
+}
+
+offline_big_cpus () {
+    for CPU in ${LIST_BIG_CPUS}; do
+        echo 0 > /sys/devices/system/cpu/cpu${CPU}/online
+    done
+}
+
+online_big_cpus () {
+    for CPU in ${LIST_BIG_CPUS}; do
+        echo 1 > /sys/devices/system/cpu/cpu${CPU}/online
+    done
+}
+
+LIST_BIG_CPUS="$( find_cpu ${BIG_CPU_PART} )"


### PR DESCRIPTION
Juno-r2 have big.LITTLE processors  2 x A57 and 4 x A53.
When KVM runs migrated from little to big or vice versa the KVM unit test
got failed. To Avoid the task migration we have to offlines big processors.

This is a complete work around to get kvm unit test runs on juno-r2.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>