### PR TITLE
boottime: run install_deps at the beginning of the script

### DIFF
--- a/automated/android/boottime/boottime.sh
+++ b/automated/android/boottime/boottime.sh
@@ -27,6 +27,7 @@ while getopts ":S:s:t:o:n:" o; do
   esac
 done
 
+install_deps 'curl tar xz-utils usbutils' "${SKIP_INSTALL}"
 
 initialize_adb
 adb_root
@@ -34,7 +35,6 @@ adb_root
 wait_homescreen "${BOOT_TIMEOUT}"
 
 create_out_dir "${OUTPUT}"
-install_deps 'curl tar xz-utils usbutils' "${SKIP_INSTALL}"
 
 adb_push "./device-script.sh" "/data/local/tmp/"
 info_msg "device-${ANDROID_SERIAL}: About to run boottime ${OPERATION} ${COLLECT_NO}..."


### PR DESCRIPTION
instead of in the middle of the test,
especially not after any adb commands

To make sure the "device not found" problem after reboot, like reported here:
https://lkft.validation.linaro.org/scheduler/job/688517#L5047

was not caused by the installation of this packages like usbutils

Change-Id: I3cadf14714ea9e69b5a1493597ac9be4e3bd444c
Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>