### PR TITLE
kvm-unit-tests.sh: set CPU affinity to CPU 0 for run_tests.sh

### DIFF
--- a/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
+++ b/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
@@ -7,15 +7,17 @@ OUTPUT="$(pwd)/output"
 RESULT_FILE="${OUTPUT}/result.txt"
 RESULT_LOG="${OUTPUT}/result_log.txt"
 SKIP_INSTALL="false"
+SMP="true"
 
 usage() {
-    echo "Usage: $0 [-s <true|false>]" 1>&2
+    echo "Usage: $0 [-s <true|false>] [-m <true|false>]" 1>&2
     exit 1
 }
 
-while getopts "s:h" o; do
+while getopts "s:m:h" o; do
   case "$o" in
     s) SKIP_INSTALL="${OPTARG}" ;;
+    m) SMP="${OPTARG}" ;;
     h|*) usage ;;
   esac
 done
@@ -37,7 +39,11 @@ parse_output() {
 
 kvm_unit_tests_run_test() {
     info_msg "running kvm unit tests ..."
-    ./run_tests.sh | tee -a "${RESULT_LOG}"
+    if [ "${SMP}" = "false" ]; then
+        taskset -c 0 ./run_tests.sh | tee -a "${RESULT_LOG}"
+    else
+        ./run_tests.sh | tee -a "${RESULT_LOG}"
+    fi
 }
 
 kvm_unit_tests_build_test() {

--- a/automated/linux/kvm-unit-tests/kvm-unit-tests.yaml
+++ b/automated/linux/kvm-unit-tests/kvm-unit-tests.yaml
@@ -23,9 +23,10 @@ metadata:
 
 params:
     SKIP_INSTALL: "False"
+    SMP: "true"
 
 run:
     steps:
         - cd ./automated/linux/kvm-unit-tests/
-        - ./kvm-unit-tests.sh -s "${SKIP_INSTALL}"
+        - ./kvm-unit-tests.sh -s "${SKIP_INSTALL}" -m "${SMP}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
kvm unit tests skipped on juno-r2 due to big.LITTLE cpu architecture.
when task migrating from big to small or vice versa tests getting skipped.
To avoid task migration on heterogeneous cpu clusters on juno-r2 devices
here we are setting CPU affinity to primary CPU 0 and run tests.

by using an extra parameter SMP.
If $SMP="false" then enforce it run with taskset
 taskset -c 0 ./run_tests.sh
else
 ./run_tests.sh

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>