### PR TITLE
memtester: fix existence check

### DIFF
--- a/automated/linux/memtester/memtester.sh
+++ b/automated/linux/memtester/memtester.sh
@@ -53,8 +53,10 @@ parser() {
 create_out_dir "${OUTPUT}"
 install
 
+set +e
 command -v memtester
 exit_on_fail "memtester-existence-check"
+set -e
 
 for i in $(seq "${ITERATIONS}"); do
     output="${OUTPUT}/memtester-iter$i.txt"


### PR DESCRIPTION
Because memtester.sh runs with "-e", the existence check was causing the
script to exit without reporting a failure, if the command didn't exist.

Run "set +e" to allow "command -v memtester" to fail with an error code,
then "set -e" again afterwards.

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>