### PR TITLE
automated/android: bail in case adb root times out

### DIFF
--- a/automated/lib/android-test-lib
+++ b/automated/lib/android-test-lib
@@ -62,8 +62,8 @@ adb_root() {
     if [ "$(adb shell whoami)" = "root" ]; then
         echo "DUT already has adbd running as root"
     else
-        adb root
-        timeout 600 adb wait-for-device || error_msg "Device NOT found!"
+        adb root || info_msg "adb root timed out"
+        timeout 600 adb wait-for-device || error_fatal "Device NOT found!"
         adb devices
         # After adb root, device number within the USB bus changes.
         adb_debug_info


### PR DESCRIPTION
Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>