### PR TITLE
network-basic: skip set interface down on NFS mounted fs

### DIFF
--- a/automated/linux/network-basic/network-basic.yaml
+++ b/automated/linux/network-basic/network-basic.yaml
@@ -28,10 +28,11 @@ metadata:
 
 params:
     INTERFACE: ""
+    NFS: "false"
     SKIP_INSTALL: "False"
 
 run:
     steps:
         - cd ./automated/linux/network-basic/
-        - ./network-basic.sh -s "${SKIP_INSTALL}" -i "${INTERFACE}"
+        - ./network-basic.sh -s "${SKIP_INSTALL}" -i "${INTERFACE}" -n "${NFS}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
network-basic: skip set interface down on NFS mounted fs

x86 running network basic test failed to make clean exit because
test case set network interface down and NFS lost connection. so
NFS parameter introduced to skip "set interface down" command when
NFS is true.

+ echo 'ip-link-interface-down pass'
[  241.270557] nfs: server 10.66.16.116 not responding, still trying
[  241.270569] nfs: server 10.66.16.116 not responding, still trying

ref:
https://lkft.validation.linaro.org/scheduler/job/735083#L1575

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>