### PR TITLE
local-daemon: fix SKIP_INSTALL

### DIFF
--- a/automated/linux/docker-integration-test/local-daemon.sh
+++ b/automated/linux/docker-integration-test/local-daemon.sh
@@ -26,7 +26,7 @@ while getopts "r:s:h" opt; do
     esac
 done
 
-if "${SKIP_INSTALL}"; then
+if [ "${SKIP_INSTALL}" = "true" ] || [ "${SKIP_INSTALL}" = "True" ]; then
     info_msg "Software installation skipped"
     # Check if required software pre-installed.
     pkgs="git make docker"


### PR DESCRIPTION
SKIP_INSTALL is set to True/true or False/false, so a simple check,
like:

  if "${SKIP_INSTALL}"; then

will fail if the string isn't all lower case, because the string is
executed as a command. Both true and false are valid commands, whereas
True and False are not.

Once the check fails, then false is selected, so it will attempt to
install, causing problems on systems where installation isn't supported,
even when the dependencies are pre-installed.

The check also fails on LAVA when the definition is passing lower case
true/false, because LAVA always passes True/False in mixed case.

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>