### PR TITLE
igt: add dump-igt-chamelium-test-result.yaml

### DIFF
--- a/automated/linux/igt/igt-chamelium-test.yaml
+++ b/automated/linux/igt/igt-chamelium-test.yaml
@@ -23,6 +23,8 @@ params:
     #TEST_LIST: "tests/vc4_ci/vc4-chamelium.testlist"
     TEST_LIST: ""
     TL: ""
+    ARTIFACTORIAL_URL: ""
+    ARTIFACTORIAL_TOKEN: ""
 
 run:
     steps:
@@ -30,4 +32,19 @@ run:
         - git config --global http.sslverify false
         - if [ -n "${TEST_LIST}" ]; then TL="-t ${TEST_LIST}"; fi
         - ./igt-chamelium-test.sh -c ${CHAMELIUM_IP} -h ${HDMI_DEV_NAME} -d ${IGT_DIR} ${TL}
+        # Dump igt test result and upload artifact to Artifactorial
+        - ifconfig; pwd; ls
+        - if [ -n "`which html2text`" -a -d "/usr/share/igt-gpu-tools/results/html/" ]; then
+        - ls /usr/share/igt-gpu-tools/results
+        - echo "**********************************************";
+        - echo "************ Dump IGT test result ************";
+        - echo "**********************************************";
+        - ls /usr/share/igt-gpu-tools/results/html/results/*|sort -r|xargs html2text; fi
+        - if [ -n "${ARTIFACTORIAL_TOKEN}" -a -n "${ARTIFACTORIAL_URL}" ]; then
+        - UPLOAD_TOOL="../../utils/upload-to-artifactorial.sh"
+        - if [ -d "/root/dump-frames/" -a -n "`ls /root/dump-frames/`" ];  then echo "Got error frames.." ; tar -C /root -zcf dump-frames.tar.gz dump-frames/;
+        - echo "*********************************************";
+        - echo "************ Upload dump frames *************";
+        - echo "*********************************************";
+        - ${UPLOAD_TOOL} -a "dump-frames.tar.gz" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"; fi; fi
         - ../../utils/send-to-lava.sh result.log


### PR DESCRIPTION
dump-igt-chamelium-test-result.yaml is used for dumping igt test result
and upload artifact to Artifactorial

Signed-off-by: Arthur She <arthur.she@linaro.org>