### PR TITLE
kselftest skiplist update

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -99,6 +99,18 @@ skiplist:
       - mq_open_tests
       - mq_perf_tests
 
+  - reason:
+      mq_perf_tests runs long so skipping
+    url:
+    environments: all
+    boards:
+      - dragonboard-410c
+      - hi6220-hikey
+      - juno-r2
+      - x15
+    branches: all
+    tests:
+      - mq_perf_tests
 
   - reason: >
       LKFT: Kselftest: rseq: Warning: file basic_test is not executable

--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -194,3 +194,17 @@ skiplist:
       - mainline
     tests:
       - test_btf
+
+  - reason: >
+      LKFT: 4.19: test_progs hangs on all devices
+    url: TBD
+    environments: all
+    boards:
+      - dragonboard-410c
+      - hi6220-hikey
+      - juno-r2
+      - qemu_arm64
+    branches:
+      - 4.19
+    tests:
+      - test_progs

--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -183,3 +183,14 @@ skiplist:
       - next
     tests:
       - zram.sh
+
+  - reason: >
+      LKFT: next: test_btf hangs on all devices
+    url: TBD
+    environments: all
+    boards: all
+    branches:
+      - next
+      - mainline
+    tests:
+      - test_btf


### PR DESCRIPTION
Updating kselftest skiplist for hangs test cases on linux next and mainline.
And when kselftest version update to 5.1 on stable branches
there is a hang for arm64 on 4.19 kernel branch due to test_progs

test_progs has to cherry-picked in to 2019.05
or 
create a new tag 2019.06 = 2019.05 + one patch [ 2c294af7cf ( kselftest: skip hang test case test_progs on 4.19 branch ) ]