### PR TITLE
igt: print igt test result with python script

### DIFF
--- a/automated/linux/igt/igt-chamelium-test.yaml
+++ b/automated/linux/igt/igt-chamelium-test.yaml
@@ -33,13 +33,11 @@ run:
         - if [ -n "${TEST_LIST}" ]; then TL="-t ${TEST_LIST}"; fi
         - ./igt-chamelium-test.sh -c ${CHAMELIUM_IP} -h ${HDMI_DEV_NAME} -d ${IGT_DIR} ${TL}
         # Dump igt test result and upload artifact to Artifactorial
-        - ifconfig; pwd; ls
-        - if [ -n "`which html2text`" -a -d "/usr/share/igt-gpu-tools/results/html/" ]; then
-        - ls /usr/share/igt-gpu-tools/results
+        - ifconfig; pwd; ls -l
         - echo "**********************************************";
         - echo "************ Dump IGT test result ************";
         - echo "**********************************************";
-        - ls /usr/share/igt-gpu-tools/results/html/results/*|sort -r|xargs html2text; fi
+        - bzcat /usr/share/igt-gpu-tools/results/results.json.bz2 | python print-test-result.py
         - if [ -n "${ARTIFACTORIAL_TOKEN}" -a -n "${ARTIFACTORIAL_URL}" ]; then
         - UPLOAD_TOOL="../../utils/upload-to-artifactorial.sh"
         - if [ -d "/root/dump-frames/" -a -n "`ls /root/dump-frames/`" ];  then echo "Got error frames.." ; tar -C /root -zcf dump-frames.tar.gz dump-frames/;

--- a/automated/linux/igt/print-test-result.py
+++ b/automated/linux/igt/print-test-result.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+import argparse
+import sys
+import json
+
+
+def print_result(results):
+    try:
+        for test, content in results['tests'].iteritems():
+            print '<LAVA_SIGNAL_STARTTC %s>' % test
+            print '************************************************************************************************************************************'
+            print '%-15s %s' % ('Test:', test)
+            print '%-15s %s' % ('Result:', content['result'])
+            print '%-15s %s' % ('Command:', content['command'])
+            print '%-15s %s' % ('Environment:', content['environment'])
+            print '%-15s %s' % ('Returncode:', content['returncode'])
+            print '%-15s %s' % ('Stdout:', content['out'].replace('\n', '\n                '))
+            print '%-15s %s' % ('Stderr:', content['err'].replace('\n', '\n                '))
+            print '%-15s %s' % ('dmesg:', content['dmesg'].replace('\n', '\n                '))
+            print '<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s RESULT=%s>' % (test, content['result'])
+            print '<LAVA_SIGNAL_ENDTC %s>' % test
+    except KeyError:
+        print "Error: Can not find required data"
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f",
+                        "--json-file",
+                        nargs='?',
+                        default=sys.stdin,
+                        type=argparse.FileType('r'),
+                        help="Test result file in json format")
+
+    args = parser.parse_args()
+    with args.json_file as data:
+        results = json.load(data)
+
+    print_result(results)


### PR DESCRIPTION
Due to html2text is quite old and the code hasn't been updated since 2005, it might be concerned to be included in the image.
Since igt-gpu-tools will generate a plain text test result and save it with JSON format.
I created a python script to print it in LAVA test log.
With this approach, html2text will not be needed.

Signed-off-by: Arthur She <arthur.she@linaro.org>