### PR TITLE
ltp: check unprivileged_userns_clone existence first

### DIFF
--- a/automated/linux/ltp/ltp.sh
+++ b/automated/linux/ltp/ltp.sh
@@ -154,9 +154,11 @@ prep_system() {
         systemctl stop systemd-timesyncd
     fi
     # userns07 requires kernel.unprivileged_userns_clone
-    if [ "$(sysctl -n kernel.unprivileged_userns_clone)" -eq 0 ]; then
+    if [ -f "/proc/sys/kernel/unprivileged_userns_clone" ]; then
         info_msg "Enabling kernel.unprivileged_userns_clone"
         sysctl -w kernel.unprivileged_userns_clone=1
+    else
+        info_msg "Kernel has no support of unprivileged_userns_clone"
     fi
 }
 


### PR DESCRIPTION
The unprivileged_userns_clone procfs entry exists only with distro
kernel with particular patch applied, e.g. the patch [1] with debian
kernel.  On development boards which mostly run upstream kernel without
such patch, the ltp script will give following message which looks like
something goes wrong.

++ sysctl -n kernel.unprivileged_userns_clone
sysctl: cannot stat /proc/sys/kernel/unprivileged_userns_clone: No such file or directory
+ '[' '' -eq 0 ']'
./ltp.sh: line 157: [: : integer expression expected

Let's check unprivileged_userns_clone existence first before accessing
it, so that we can avoid above "error" messages and the confusion caused
by it.

[1] https://salsa.debian.org/kernel-team/linux/blob/master/debian/patches/debian/add-sysctl-to-disallow-unprivileged-CLONE_NEWUSER-by-default.patch

Signed-off-by: Shawn Guo <shawn.guo@linaro.org>