### PR TITLE
tradefed monitor_fastboot.sh: support more boot image names

### DIFF
--- a/automated/android/noninteractive-tradefed/monitor_fastboot.sh
+++ b/automated/android/noninteractive-tradefed/monitor_fastboot.sh
@@ -2,6 +2,6 @@
 while true;
 do
     date
-    fastboot boot /lava-lxc/boot*.img
+    fastboot boot /lava-lxc/*boot*.img
     sleep 30
 done


### PR DESCRIPTION
to work around problems like reported here:

nice lxc-attach -n lxc-test-1919582 -- fastboot -s 28146262003EFFEE flash boot /lava-lxc/lkft-hikey-android-9.0-mainline-boot.img

Thu Jun 20 08:45:49 UTC 2019
+ fastboot boot /lava-lxc/boot*.img
fastboot: error: cannot load '/lava-lxc/boot*.img': No such file or directory
+ sleep 30

https://validation.linaro.org/scheduler/job/1919582#L5627

Change-Id: Ie4e45e22ef203ea0c519979a2b411328ca3ccce9
Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>