### PR TITLE
noninteractive-tradefed: use jdk8 and remove _JAVA_OPTIONS

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -5,19 +5,8 @@
 . ../../lib/sh-test-lib
 . ../../lib/android-test-lib
 
-# ANDROID_VERSION was set in the format like change here:
-# https://review.linaro.org/#/c/ci/job/configs/+/29367/
-if [ -z "${ANDROID_VERSION}" ]; then
-    # install jdk8 when nothing specified
-    # to avoid regression
-    JDK="openjdk-8-jdk-headless"
-elif echo "${ANDROID_VERSION}" | grep -q  "android-8\." ; then
-    # install jdk8 for Oreo builds, both 8.0 and 8.1
-    JDK="openjdk-8-jdk-headless"
-else
-    # Use Jdk9 for all other builds
-    JDK="openjdk-9-jdk-headless"
-fi
+JDK="openjdk-8-jdk-headless"
+
 PKG_DEPS="coreutils usbutils curl wget zip xz-utils python-lxml python-setuptools python-pexpect aapt lib32z1-dev libc6-dev-i386 lib32gcc1 libc6:i386 libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 python-dev python-protobuf protobuf-compiler python-virtualenv python-pip python-pexpect psmisc"
 
 dist_name

--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -57,10 +57,6 @@ disable_suspend
 # sufficient.
 # wait_homescreen "${TIMEOUT}"
 
-# Increase the heap size. KVM devices in LAVA default to ~250M of heap
-export _JAVA_OPTIONS="-Xmx350M"
-java -version
-
 # Download CTS/VTS test package or copy it from local disk.
 if echo "${TEST_URL}" | grep "^http" ; then
     wget -S --progress=dot:giga "${TEST_URL}"

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -34,10 +34,9 @@ params:
     # Specify the failures number to be printed
     FAILURES_PRINTED: "0"
     TEST_REBOOT_EXPECTED: "false"
-    # setup.sh determines JDK version by Android version.
-    # Here are some examples for the param, see setup.sh for more details.
-    # ANDROID_VERSION: android-8.1.0_r33
-    # ANDROID_VERSION: aosp-master
+    # leave ANDROID_VERSION here as a stub so that jobs have ANDROID_VERSION specified won't report any problem
+    # but it is not used any more, the default openjdk-8 will be used for cts/vts test
+    # and in the future, maybe the jdk package installation is better to be done with the host deploy action
     ANDROID_VERSION: ""
 
 run:

--- a/automated/android/tradefed/setup.sh
+++ b/automated/android/tradefed/setup.sh
@@ -5,11 +5,7 @@
 . ../../lib/sh-test-lib
 . ../../lib/android-test-lib
 
-if echo "$ANDROID_VERSION" | grep aosp-master ; then
-    JDK="openjdk-9-jdk-headless"
-else
-    JDK="openjdk-8-jdk-headless"
-fi
+JDK="openjdk-8-jdk-headless"
 PKG_DEPS="usbutils curl wget zip xz-utils python-lxml python-setuptools python-pexpect aapt lib32z1-dev libc6-dev-i386 lib32gcc1 libc6:i386 libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 python-dev python-protobuf protobuf-compiler python-virtualenv python-pip python-pexpect psmisc"
 
 dist_name

--- a/automated/android/tradefed/tradefed.sh
+++ b/automated/android/tradefed/tradefed.sh
@@ -19,14 +19,13 @@ FAILURES_PRINTED="0"
 AP_SSID=""
 # WIFI AP KEY
 AP_KEY=""
-JAVA_OPTIONS="-Xmx350M"
 
 usage() {
     echo "Usage: $0 [-o timeout] [-n serialno] [-c cts_url] [-t test_params] [-p test_path] [-r <aggregated|atomic>] [-f failures_printed] [-a <ap_ssid>] [-k <ap_key>]" 1>&2
     exit 1
 }
 
-while getopts ':o:n:c:t:p:r:f:a:k:j:' opt; do
+while getopts ':o:n:c:t:p:r:f:a:k:' opt; do
     case "${opt}" in
         o) TIMEOUT="${OPTARG}" ;;
         n) export ANDROID_SERIAL="${OPTARG}" ;;
@@ -37,7 +36,6 @@ while getopts ':o:n:c:t:p:r:f:a:k:j:' opt; do
         f) FAILURES_PRINTED="${OPTARG}" ;;
         a) AP_SSID="${OPTARG}" ;;
         k) AP_KEY="${OPTARG}" ;;
-        j) JAVA_OPTIONS="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -58,10 +56,6 @@ disable_suspend
 # comment out wait_homescreen() and see if wait_boot_completed() is
 # sufficient.
 # wait_homescreen "${TIMEOUT}"
-
-# Increase the heap size. KVM devices in LAVA default to ~250M of heap
-export _JAVA_OPTIONS="${JAVA_OPTIONS}"
-java -version
 
 # Download CTS/VTS test package or copy it from local disk.
 if echo "${TEST_URL}" | grep "^http" ; then

--- a/automated/android/tradefed/tradefed.yaml
+++ b/automated/android/tradefed/tradefed.yaml
@@ -34,11 +34,9 @@ params:
     # Specify the failures number to be printed
     FAILURES_PRINTED: "0"
     TEST_REBOOT_EXPECTED: "false"
-    JAVA_OPTIONS: "-Xmx350M"
-    # setup.sh determines JDK version by Android version.
-    # Here are some examples for the param, see setup.sh for more details.
-    # ANDROID_VERSION: android-8.1.0_r33
-    # ANDROID_VERSION: aosp-master
+    # leave ANDROID_VERSION here as a stub so that jobs have ANDROID_VERSION specified won't report any problem
+    # but it is not used any more, the default openjdk-8 will be used for cts/vts test
+    # and in the future, maybe the jdk package installation is better to be done with the host deploy action
     ANDROID_VERSION: ""
 
 run:


### PR DESCRIPTION
1. the _JAVA_OPTIONS confuses the java version check in cts/vts
   and as cts/vts try to allocate more memory in their scripts following:
     https://android.googlesource.com/platform/test/vts/+/refs/heads/master/tools/vts-tradefed/etc/vts-tradefed#187
     https://android.googlesource.com/platform/test/suite_harness/+/refs/heads/master/tools/cts-tradefed/etc/cts-tradefed#133
   there is no meaning to set _JAVA_OPTIONS any more.

2. fixed to use jdk8 for vts/cts test
   as the installed openjdk-9-jdk-headless would cause following error with vts test:

   Using commandline arguments as starting command: [run, commandAndExit, vts-kernel, --module, VtsKernelLinuxKselftest]
   java.lang.reflect.InaccessibleObjectException: Unable to make member of class sun.reflect.annotation.AnnotationInvocationHandler accessible:  module java.base does not export sun.reflect.annotation to unnamed module @3224f60b
    at sun.reflect.Reflection.throwInaccessibleObjectException(java.base@9-internal/Reflection.java:420)
    at java.lang.reflect.AccessibleObject.checkCanSetAccessible(java.base@9-internal/AccessibleObject.java:174)
    at java.lang.reflect.Field.checkCanSetAccessible(java.base@9-internal/Field.java:170)
    at java.lang.reflect.Field.setAccessible(java.base@9-internal/Field.java:164)
    at com.android.tradefed.config.OptionSetter.updateOptionChangedField(OptionSetter.java:556)
    at com.android.tradefed.config.OptionSetter.setFieldValue(OptionSetter.java:538)
    at com.android.tradefed.config.OptionSetter.setOptionValue(OptionSetter.java:414)
    at com.android.tradefed.config.OptionSetter.setOptionValue(OptionSetter.java:359)
    at com.android.compatibility.common.tradefed.testtype.suite.CompatibilityTestSuite.<init>(CompatibilityTestSuite.java:74)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(java.base@9-internal/Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(java.base@9-internal/NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(java.base@9-internal/DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(java.base@9-internal/Constructor.java:453)
    at java.lang.Class.newInstance(java.base@9-internal/Class.java:550)
    at com.android.tradefed.config.ConfigurationDef.createObject(ConfigurationDef.java:423)
    at com.android.tradefed.config.ConfigurationDef.createConfiguration(ConfigurationDef.java:252)
    at com.android.tradefed.config.ConfigurationFactory.internalCreateConfigurationFromArgs(ConfigurationFactory.java:573)
    at com.android.tradefed.config.ConfigurationFactory.createConfigurationFromArgs(ConfigurationFactory.java:495)
    at com.android.tradefed.command.CommandScheduler.createConfiguration(CommandScheduler.java:1191)
    at com.android.tradefed.command.CommandScheduler.internalAddCommand(CommandScheduler.java:1201)
    at com.android.tradefed.command.CommandScheduler.addCommand(CommandScheduler.java:1146)
    at com.android.tradefed.command.CommandScheduler.addCommand(CommandScheduler.java:1138)
    at com.android.tradefed.command.Console$27.run(Console.java:736)
    at com.android.tradefed.command.Console$27.run(Console.java:727)
    at com.android.tradefed.command.Console.executeCmdRunnable(Console.java:926)
    at com.android.tradefed.command.Console.run(Console.java:1028)
    at com.android.compatibility.common.tradefed.command.CompatibilityConsole.run(CompatibilityConsole.java:104)
   07-10 04:46:57 V/LogRegistry: Saved log to /tmp/tradefed_global_log_6919477904182546528.txt

    after the change here:
    https://android-review.googlesource.com/c/platform/tools/tradefederation/+/1010290/3/src/com/android/tradefed/config/OptionSetter.java

Change-Id: Ib972a8c3ca8c3e9b6ea2a07e03b42e357d487b34
Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>