### PR TITLE
Add hci scanning and inquiry to the hci smoke tests

### DIFF
--- a/automated/linux/hci-smoke/hci-smoke-test.sh
+++ b/automated/linux/hci-smoke/hci-smoke-test.sh
@@ -60,6 +60,7 @@ test_hciconfig_boot() {
     if [ "${BOOT}" = "auto" ]; then
         # get rid of spaces and comments
         sed 's/\s\+//g;/^#/d' /etc/bluetooth/main.conf | grep "^AutoEnable=true"
+	# shellcheck disable=SC2181
         if [ "$?" -eq 0 ]; then
             BOOT="enabled"
         else

--- a/automated/linux/hci-smoke/hci-smoke-test.sh
+++ b/automated/linux/hci-smoke/hci-smoke-test.sh
@@ -29,6 +29,9 @@ export RESULT_FILE
 DEVICE="hci0"
 BOOT="enabled"
 
+# Pattern for HCI device baddr
+BADDR_PATTERN="..:..:..:..:..:.."
+
 usage() {
     echo "Usage: $0 [-b <enabled|disabled>] [-d <device>]" 1>&2
     exit 1
@@ -89,6 +92,24 @@ test_hciconfig_down() {
     check_return "hciconfig-down"
 }
 
+# Test HCI device scanning
+test_hcitool_scan() {
+    info_msg "Running hcitool-scan test..."
+    hcitool -i "${DEVICE}" scan
+    check_return "hciconfig-scan"
+    hcitool -i "${DEVICE}" scan | grep $BADDR_PATTERN
+    check_return "hciconfig-scan (verify available devices)"
+}
+
+# Test HCI device inquiry
+test_hcitool_inq() {
+    info_msg "Running hcitool-inq test..."
+    hcitool -i "${DEVICE}" inq
+    check_return "hciconfig-inq"
+    hcitool -i "${DEVICE}" inq | grep $BADDR_PATTERN
+    check_return "hciconfig-inq (verify available devices)"
+}
+
 # Test run.
 ! check_root && error_msg "This script must be run as root"
 create_out_dir "${OUTPUT}"
@@ -101,6 +122,8 @@ test_hciconfig
 test_hciconfig_boot
 test_hciconfig_down
 test_hciconfig_up
+test_hcitool_scan
+test_hcitool_inq
 
 
 


### PR DESCRIPTION
This change improves the hci smoke test slightly by testing scan and inquiry commands. It also checks to make sure available devices show up in the listing.

We may want to pass a param to the test telling it if there are actual devices around the tested hardware.

This is the output from a test run:

Testing output from running hci-smoke-test.sh:

INFO: About to run HCI smoke test...
INFO: Output directory: /home/user/automated/linux/hci-smoke/output
INFO: Running hciconfig test...
hci0:	Type: Primary  Bus: USB
	BD Address: AC:ED:5C:44:A2:31  ACL MTU: 1021:4  SCO MTU: 96:6
	UP RUNNING PSCAN 
	RX bytes:103593611 acl:1117 sco:0 events:14794579 errors:0
	TX bytes:-246215823 acl:14791514 sco:0 commands:2734 errors:0

hciconfig pass
INFO: Running hciconfig_boot test...
	UP RUNNING PSCAN 
hciconfig-boot-enabled pass
INFO: Running hciconfig-down test...
	DOWN 
hciconfig-down pass
INFO: Running hciconfig-up test...
	UP RUNNING PSCAN 
hciconfig-up pass
INFO: Running hcitool-scan test...
Scanning ...
	00:1D:5C:00:26:66	OBDII
hciconfig-scan pass
	00:1D:5C:00:26:66	OBDII
hciconfig-scan (verify available devices) pass
INFO: Running hcitool-inq test...
Inquiring ...
	00:1D:5C:00:26:66	clock offset: 0x1faf	class: 0x001f00
hciconfig-inq pass
	00:1D:5C:00:26:66	clock offset: 0x1fae	class: 0x001f00
hciconfig-inq (verify available devices) pass

Does this look OK to merge?