### PR TITLE
New kernel config file checker

### DIFF
--- a/automated/linux/kernel-config-checker/kernel-config-checker.sh
+++ b/automated/linux/kernel-config-checker/kernel-config-checker.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+#
+# Kernel config checker
+#
+# Checks if a set of CONFIG_* values are defined in the config file for a
+# particular version of the Linux kernel.
+#
+# Copyright (C) 2019, Linaro Limited.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+# shellcheck disable=SC1091
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+export RESULT_FILE
+kernel_config=""
+
+# A list of space-separated config values to be checked.
+# Example: CONFIG_VALUES="CONFIG_X CONFIG_Y CONFIG_Z"
+CONFIG_VALUES=''
+
+usage() {
+    echo "Usage: $0 [-c config_values]" 1>&2
+    exit 1
+}
+
+while getopts "c:h" o; do
+    case "$o" in
+        c) CONFIG_VALUES="${OPTARG}" ;;
+        h|*) usage ;;
+    esac
+done
+
+# Find the location of the kernel's config file based on various standard
+# locations.
+find_config_file() {
+    if [ -e "/boot/config-$(uname -r)" ]; then
+	kernel_config="/boot/config-$(uname -r)"
+    elif [ -e "/lib/modules/$(uname -r)/config" ]; then
+	kernel_config="/lib/modules/$(uname -r)/config"
+    elif [ -e "/lib/kernel/config-$(uname -r)" ]; then
+	kernel_config="/lib/kernel/config-$(uname -r)"
+    fi
+}
+
+check_config() {
+
+    # Fetch the config file.
+    find_config_file
+
+    if [ ! -f "${kernel_config}" ]; then
+	 exit_on_fail "Kernel Config File ${kernel_config} does not exist..."
+    fi
+
+    info_msg "Found kernel config file in $kernel_config."
+
+    # shellcheck disable=SC2068
+    for c in ${@}; do
+	info_msg "Checking config option ${c}..."
+	cat < "${kernel_config}" | grep "${c}=[y|m]" > /dev/null
+	check_return "config value: ${c}"
+    done
+}
+
+# Test run.
+create_out_dir "${OUTPUT}"
+
+info_msg "About to run kernel config checker test..."
+info_msg "Output directory: ${OUTPUT}"
+
+check_config "${CONFIG_VALUES}"

--- a/automated/linux/kernel-config-checker/kernel-config-checker.yaml
+++ b/automated/linux/kernel-config-checker/kernel-config-checker.yaml
@@ -1,0 +1,35 @@
+metadata:
+    name: kernel-config-checker
+    format: "Lava-Test-Shell Test Definition 1.0"
+    description: "Check the kernel config file for the presence of required
+		  CONFIG_* values."
+    maintainer:
+        - luis.machado@linaro.org
+    os:
+        - debian
+        - ubuntu
+        - fedora
+        - centos
+    scope:
+        - functional
+        - performance
+    environment:
+        - lava-test-shell
+    devices:
+        - hi6220-hikey
+        - apq8016-sbc
+        - mustang
+        - moonshot
+        - thunderX
+        - d03
+        - d05
+
+params:
+    # Specify a space-separated list of kernel config values to check.
+    CONFIG_VALUES: ""
+
+run:
+    steps:
+        - cd ./automated/linux/kernel-config-checker/
+        - ./kernel-config-checker.sh -c "${CONFIG_VALUES}"
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Add new test to check the kernel config file for the presence of multiple
CONFIG_* values.

* kernel-config-checker.sh: New kernel config file checker script.
* kernel-config-checker.yaml: New kernel config file checker test.

Signed-off-by: Luis Machado <luis.machado@linaro.org>