### PR TITLE
Added test definition to drive ion-monitor-tool for Android.

### DIFF
--- a/automated/android/ion-monitor-tool/example-job.yaml
+++ b/automated/android/ion-monitor-tool/example-job.yaml
@@ -1,0 +1,96 @@
+device_type: <your-device>
+job_name: ion-monitor-tool
+
+timeouts:
+  job:
+    hours: 5
+  action:
+    hours: 1
+  connection:
+    minutes: 5
+priority: medium
+visibility: public
+
+metadata:
+  os: android
+  android.version: 9.0.0
+  test: ion-monitor
+
+# you will need internet to play video with Exoplayer.
+secrets:
+  AP_SSID: "SSID"
+  AP_KEY: "KEY"
+
+protocols:
+  lava-lxc:
+    name: android_9_ion_monitor
+    template: download
+    distribution: ubuntu
+    release: xenial
+    arch: amd64
+    verbose: true
+    persist: false
+
+actions:
+- deploy:
+    namespace: lxcEnv
+    timeout:
+      minutes: 20
+    to: lxc
+    packages: 
+    - android-tools-adb
+    - android-tools-fastboot
+    - git
+    - wget
+    - curl
+    os: debian
+
+- boot:
+    namespace: lxcEnv
+    prompts:
+    - 'root@(.*):'
+    timeout:
+      minutes: 5
+    method: lxc
+
+- boot:
+    namespace: dutEnv
+    method: fastboot
+    prompts:
+     - '<device-prompt>'
+    timeout:
+      minutes: 10
+
+- test:
+   namespace: lxcEnv
+   timeout:
+     hours: 2
+   definitions:
+    - repository: https://github.com/Linaro/test-definitions.git
+      from: git
+      path: automated/android/ion-monitor-tool/ion-monitor-tool.yaml
+      params:
+          HEAP: "/sys/kernel/debug/ion/display"
+          REPEAT: "10"
+          CLEAR: "true"
+          SECURE: "false"
+          UHD: "false"
+          BINARY_URL: "https://github.com/linaro-mmwg/ionmonitortool/releases/download/V1.0/ion-monitor-tool"
+      name: ion-monitor-display
+
+- test:
+   namespace: lxcEnv
+   timeout:
+     hours: 2
+   definitions:
+    - repository: https://github.com/Linaro/test-definitions.git
+      from: git
+      path: automated/android/ion-monitor-tool/ion-monitor-tool.yaml
+      params:
+          HEAP: "/sys/kernel/debug/ion/optee"
+          REPEAT: "10"
+          CLEAR: "false"
+          SECURE: "true"
+          UHD: "false"
+          BINARY_URL: "https://github.com/linaro-mmwg/ionmonitortool/releases/download/V1.0/ion-monitor-tool"
+      name: ion-monitor-optee

--- a/automated/android/ion-monitor-tool/ion-monitor-tool.yaml
+++ b/automated/android/ion-monitor-tool/ion-monitor-tool.yaml
@@ -1,0 +1,41 @@
+metadata:
+    name: ion-monitor-tool
+    format: "Lava-Test-Shell Test Definition 1.0"
+    description: "Run ion monitor tool to check memory leaks."
+    maintainer:
+        - axel.lebourhis@linaro.org
+    os:
+        - ubuntu
+    devices:
+        - lxc
+
+params:
+    HEAP: "/sys/kernel/debug/ion/display"
+    REPEAT: "5"
+    CLEAR: "true"
+    SECURE: "false"
+    UHD: "false"
+    UPLOAD_URL: ""
+    BINARY_URL: "https://github.com/linaro-mmwg/ionmonitortool/releases/download/V1.0/ion-monitor-tool"
+
+run:
+    steps:
+        - cd ./automated/android/ion-monitor-tool
+        - . ./setup.sh 
+        - echo "Setup done"
+        - wget ${BINARY_URL} -O ion-monitor-tool.bin
+        - adb push ./ion-monitor-tool.bin /data
+        - ./runner.sh -h ${HEAP} -r ${REPEAT} -c ${CLEAR} -s ${SECURE} -u ${UHD}
+        - mkdir -p ./output
+        # retrieve logs from the tool
+        - adb pull /data/allocated_size.log ./output
+        - adb pull /data/free_size.log ./output
+        - adb pull /data/allocated_peak.log ./output
+        - adb pull /data/largest_free_buffer.log ./output
+        - adb pull /data/heap_fragmentation.log ./output
+        # prepare archive
+        - ATTACHMENT="ion-monitor-tool-$(date +%Y%m%d-%H%M).tar.xz"
+        - tar caf "${ATTACHMENT}" output
+        # upload archive if server URL provided
+        - if [ ! -z "${UPLOAD_URL}" ]; then curl -F "file=@${ATTACHMENT}" "${UPLOAD_URL}"; fi
+        - if [ ! -z "${UPLOAD_URL}" ]; then lava-test-reference "test-attachment" --result "pass" --reference "${UPLOAD_URL}${ATTACHMENT}"; fi

--- a/automated/android/ion-monitor-tool/runner.sh
+++ b/automated/android/ion-monitor-tool/runner.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -ex
+
+HEAP="/sys/kernel/debug/ion/display"
+REPEAT="5"
+CLEAR="true"
+SECURE="false"
+UHD="false"
+
+usage() {
+    echo "Usage: $0 [-h heap path] [-r number of repeat] [-c include clear playback] [-s include secure playback] [-u include UHD playback]" 1>&2
+    exit 1
+}
+
+while getopts h:r:c:s:u: option
+do
+case "${option}"
+in
+h) HEAP=${OPTARG};;
+r) REPEAT=${OPTARG};;
+c) CLEAR=${OPTARG};;
+s) SECURE=${OPTARG};;
+u) UHD=${OPTARG};;
+*) usage;;
+
+esac
+done
+
+COMMAND="cd /data && ./ion-monitor-tool.bin -f ${HEAP} -r ${REPEAT}"
+
+if [ "$CLEAR" = "true" ]; then
+    COMMAND="${COMMAND} -c"
+fi
+
+if [ "$SECURE" = "true" ]; then
+    COMMAND="${COMMAND} -s"
+fi
+
+if [ "$UHD" = "true" ]; then
+    COMMAND="${COMMAND} -u"
+fi
+
+adb shell "${COMMAND}" | tee ./stdout.log
+
+<./stdout.log grep RESULT | awk '{print $2" "$3""}' | sed "s/FAIL/fail/; s/PASS/pass/" > results.txt
+while read -r line
+do
+    TEST_CASE=$(echo "${line}" | awk '{print $1}')
+    RESULT=$(echo "${line}" | awk '{print $2}')
+    echo "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=${TEST_CASE} RESULT=${RESULT}>"
+done < "results.txt"
+
+exit 0

--- a/automated/android/ion-monitor-tool/setup.sh
+++ b/automated/android/ion-monitor-tool/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -x
+# shellcheck disable=SC2154
+# shellcheck disable=SC1091
+
+. ../../lib/sh-test-lib
+. ../../lib/android-test-lib
+
+install_latest_adb
+wait_boot_completed "300"
+adb root
+adb_join_wifi


### PR DESCRIPTION
Also added an example test job for LAVA.
This tool comes from MMWG team, to help monitoring memory leaks with ION heaps.

Signed-off-by: Axel Le Bourhis <axel.lebourhis@nxp.com>