### PR TITLE
[WIP] Add background cmd

### DIFF
--- a/automated/lib/sh-test-lib
+++ b/automated/lib/sh-test-lib
@@ -7,7 +7,7 @@ error_fatal() {
     # shellcheck disable=SC2039
     local msg="$1"
     [ -z "${msg}" ] && msg="Unknown error"
-    if which lava-test-raise;then
+    if command -v lava-test-raise; then
         lava-test-raise "${msg}"
     else
         printf "FATAL ERROR: %s\n" "${msg}" >&2

--- a/automated/lib/sh-test-lib
+++ b/automated/lib/sh-test-lib
@@ -476,3 +476,64 @@ generate_skipfile() {
     cat "${SKIPFILE_PATH}"
     info_msg "EOF"
 }
+
+background_process_start() {
+    NAME="$1"
+    shift
+    if [ -z "$NAME" ]; then
+	err_msg "Usage: background-process-start NAME --cmd PROCESS"
+    fi
+
+    while [ $# -gt 0 ]; do
+	case $1 in
+            --cmd)
+		shift
+		PROCESS="$*"
+		shift
+		;;
+            *)
+		err_msg "Unhandled argument"
+		;;
+	esac
+    done
+
+    if [ -z "${PROCESS}" ]; then
+	return
+    fi
+
+    result_dir="${OUTPUT}/results/$NAME"
+    mkdir -p "${result_dir}"
+
+    cat <<EOF > "${result_dir}/bg_run.sh"
+set -e
+trap "exit" SIGHUP SIGINT SIGTERM
+while true; do
+  $PROCESS > /dev/null &
+  sleep 1
+done
+EOF
+
+    /bin/bash "${result_dir}/bg_run.sh" &
+    echo $! > "${result_dir}/pid"
+}
+
+background_process_stop() {
+    NAME="$1"
+    shift
+    if [ -z "${NAME}" ]; then
+	err_msg "Usage: background-process-stop NAME"
+    fi
+
+    result_dir="${OUTPUT}/results/${NAME}"
+
+    if [ ! -d "${result_dir}" ] ; then
+	return
+    fi
+
+    PID=$(cat "${result_dir}/pid")
+
+    if ps -p "${PID}" > /dev/null;
+    then
+	kill "${PID}" > /dev/null 2>&1
+    fi
+}

--- a/automated/linux/cyclicdeadline/cyclicdeadline.sh
+++ b/automated/linux/cyclicdeadline/cyclicdeadline.sh
@@ -15,19 +15,21 @@ STEP="500"
 THREADS="1"
 DURATION="1m"
 MAX_LATENCY="50"
+BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-i interval] [-s step] [-t threads] [-D duration ] [-m latency]" 1>&2
+    echo "Usage: $0 [-i interval] [-s step] [-t threads] [-D duration ] [-m latency] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":i:s:t:D:m:" opt; do
+while getopts ":i:s:t:D:m:w:" opt; do
     case "${opt}" in
         i) INTERVAL="${OPTARG}" ;;
 	s) STEP="${STEP}" ;;
         t) THREADS="${OPTARG}" ;;
         D) DURATION="${OPTARG}" ;;
 	m) MAX_LATENCY="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -41,8 +43,13 @@ if ! binary=$(command -v cyclicdeadline); then
     # shellcheck disable=SC2154
     binary="./bin/${abi}/cyclicdeadline"
 fi
+
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
 "${binary}" -i "${INTERVAL}" -s "${STEP}" -t "${THREADS}" \
 	-D "${DURATION}" | tee "${LOGFILE}"
+
+background_process_stop bgcmd
 
 # Parse test log.
 ../../lib/parse_rt_tests_results.py cyclicdeadline "${LOGFILE}" "${MAX_LATENCY}" \

--- a/automated/linux/cyclicdeadline/cyclicdeadline.yaml
+++ b/automated/linux/cyclicdeadline/cyclicdeadline.yaml
@@ -39,9 +39,11 @@ params:
     # Maximal accepted latency in us
     # This value is device/kernel specific and needs to be set in the job!
     MAX_LATENCY: "50"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/cyclicdeadline/
-        - ./cyclicdeadline.sh -i "${INTERVAL}" -s "${STEP}" -t "${THREADS}" -D "${DURATION}" -m "${MAX_LATENCY}"
+        - ./cyclicdeadline.sh -i "${INTERVAL}" -s "${STEP}" -t "${THREADS}" -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/cyclictest/cyclictest.sh
+++ b/automated/linux/cyclictest/cyclictest.sh
@@ -16,13 +16,14 @@ THREADS="1"
 AFFINITY="0"
 DURATION="1m"
 MAX_LATENCY="50"
+BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-p priority] [-i interval] [-t threads] [-a affinity] [-D duration ] [-m latency]" 1>&2
+    echo "Usage: $0 [-p priority] [-i interval] [-t threads] [-a affinity] [-D duration ] [-m latency] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":p:i:t:a:D:m:" opt; do
+while getopts ":p:i:t:a:D:m:w:" opt; do
     case "${opt}" in
         p) PRIORITY="${OPTARG}" ;;
         i) INTERVAL="${OPTARG}" ;;
@@ -30,6 +31,7 @@ while getopts ":p:i:t:a:D:m:" opt; do
 	a) AFFINITY="${OPTARG}" ;;
         D) DURATION="${OPTARG}" ;;
 	m) MAX_LATENCY="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -38,13 +40,18 @@ done
 create_out_dir "${OUTPUT}"
 
 # Run cyclictest.
-if ! binary=$(which cyclictest); then
+if ! binary=$(command -v cyclictest); then
     detect_abi
     # shellcheck disable=SC2154
     binary="./bin/${abi}/cyclictest"
 fi
+
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
 "${binary}" -p "${PRIORITY}" -i "${INTERVAL}" -t "${THREADS}" -a "${AFFINITY}" \
     -D "${DURATION}" -m | tee "${LOGFILE}"
+
+background_process_stop bgcmd
 
 # Parse test log.
 ../../lib/parse_rt_tests_results.py cyclictest "${LOGFILE}" "${MAX_LATENCY}" \

--- a/automated/linux/cyclictest/cyclictest.yaml
+++ b/automated/linux/cyclictest/cyclictest.yaml
@@ -41,9 +41,11 @@ params:
     # Maximal accepted latency in us
     # This value is device/kernel specific and needs to be set in the job!
     MAX_LATENCY: "50"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/cyclictest/
-        - ./cyclictest.sh -D "${DURATION}" -p "${PRIORITY}" -i "${INTERVAL}" -t "${THREADS}" -a "${AFFINITY}"  -m "${MAX_LATENCY}"
+        - ./cyclictest.sh -D "${DURATION}" -p "${PRIORITY}" -i "${INTERVAL}" -t "${THREADS}" -a "${AFFINITY}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/pi-stress/pi-stress.sh
+++ b/automated/linux/pi-stress/pi-stress.sh
@@ -14,17 +14,19 @@ export RESULT_FILE
 DURATION="5m"
 MLOCKALL="false"
 RR="false"
+BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-D runtime] [-m <true|false>] [-r <true|false>]" 1>&2
+    echo "Usage: $0 [-D runtime] [-m <true|false>] [-r <true|false>] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:r:" opt; do
+while getopts ":D:m:r:w" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
         m) MLOCKALL="${OPTARG}" ;;
         r) RR="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -43,15 +45,20 @@ else
     RR=""
 fi
 
-if ! binary=$(which pi_stress); then
+if ! binary=$(command -v pi_stress); then
     detect_abi
     # shellcheck disable=SC2154
     binary="./bin/${abi}/pi_stress"
 fi
+
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
 # pi_stress will send SIGTERM when test fails. The single will terminate the
 # test script. Catch and ignore it with trap.
 trap '' TERM
 "${binary}" --duration "${DURATION}" "${MLOCKALL}" "${RR}" | tee "${LOGFILE}"
+
+background_process_stop bgcmd
 
 # shellcheck disable=SC2181
 if [ "$?" -ne "0" ]; then

--- a/automated/linux/pi-stress/pi-stress.yaml
+++ b/automated/linux/pi-stress/pi-stress.yaml
@@ -32,9 +32,11 @@ params:
     # Set RR to "true" to use SCHED_RR for test threads.
     # It uses SCHED_FIFO by default.
     RR: "false"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd automated/linux/pi-stress
-        - ./pi-stress.sh -D "${DURATION}" -m "${MLOCKALL}" -r "${RR}"
+        - ./pi-stress.sh -D "${DURATION}" -m "${MLOCKALL}" -r "${RR}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/pmqtest/pmqtest.sh
+++ b/automated/linux/pmqtest/pmqtest.sh
@@ -10,16 +10,18 @@ LOGFILE="${OUTPUT}/pmqtest.log"
 RESULT_FILE="${OUTPUT}/result.txt"
 DURATION="5m"
 MAX_LATENCY="100"
+BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-D duration] [-m latency]" 1>&2
+    echo "Usage: $0 [-D duration] [-m latency] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:" opt; do
+while getopts ":D:m:w:" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
 	m) MAX_LATENCY="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -30,13 +32,17 @@ done
 create_out_dir "${OUTPUT}"
 
 # Run pmqtest.
-if ! binary=$(which pmqtest); then
+if ! binary=$(command -v pmqtest); then
     detect_abi
     # shellcheck disable=SC2154
     binary="./bin/${abi}/pmqtest"
 fi
 
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
 "${binary}" -S -p 98 -D "${DURATION}" | tee "${LOGFILE}"
+
+background_process_stop bgcmd
 
 # Parse test log.
 ../../lib/parse_rt_tests_results.py pmqtest "${LOGFILE}" "${MAX_LATENCY}" \

--- a/automated/linux/pmqtest/pmqtest.yaml
+++ b/automated/linux/pmqtest/pmqtest.yaml
@@ -30,9 +30,11 @@ params:
     # Maximal accepted latency in us
     # This value is device/kernel specific and needs to be set in the job!
     MAX_LATENCY: "100"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/pmqtest/
-        - ./pmqtest.sh -D "${DURATION}" -m "${MAX_LATENCY}"
+        - ./pmqtest.sh -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ptsematest/ptsematest.sh
+++ b/automated/linux/ptsematest/ptsematest.sh
@@ -9,16 +9,18 @@ LOGFILE="${OUTPUT}/ptsematest.log"
 RESULT_FILE="${OUTPUT}/result.txt"
 DURATION="5m"
 MAX_LATENCY="100"
+BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-D duration] [-m latency]" 1>&2
+    echo "Usage: $0 [-D duration] [-m latency] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:" opt; do
+while getopts ":D:m:w:" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
 	m) MAX_LATENCY="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -35,7 +37,11 @@ if ! binary=$(command -v ptsematest); then
     binary="./bin/${abi}/ptsematest"
 fi
 
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
 "${binary}" -S -p 98 -D "${DURATION}" | tee "${LOGFILE}"
+
+background_process_stop bgcmd
 
 # Parse test log.
 ../../lib/parse_rt_tests_results.py ptsematest "${LOGFILE}" "${MAX_LATENCY}" \

--- a/automated/linux/ptsematest/ptsematest.yaml
+++ b/automated/linux/ptsematest/ptsematest.yaml
@@ -32,9 +32,11 @@ params:
     # Maximal accepted latency in us
     # This value is device/kernel specific and needs to be set in the job!
     MAX_LATENCY: "100"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/ptsematest/
-        - ./ptsematest.sh -D "${DURATION}" -m "${MAX_LATENCY}"
+        - ./ptsematest.sh -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/rt-migrate-test/rt-migrate-test.sh
+++ b/automated/linux/rt-migrate-test/rt-migrate-test.sh
@@ -9,16 +9,18 @@ LOGFILE="${OUTPUT}/rt-migrate-test.txt"
 RESULT_FILE="${OUTPUT}/result.txt"
 PRIORITY="96"
 DURATION="1m"
+BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-p priority] [-D duration]" 1>&2
+    echo "Usage: $0 [-p priority] [-D duration] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":l:p:D:" opt; do
+while getopts ":l:p:D:w:" opt; do
     case "${opt}" in
 	p) PRIORITY="${OPTARG}" ;;
 	D) DURATION="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -27,12 +29,17 @@ done
 create_out_dir "${OUTPUT}"
 
 # Run rt-migrate-test.
-if ! binary=$(which rt-migrate-test); then
+if ! binary=$(command -v rt-migrate-test); then
     detect_abi
     # shellcheck disable=SC2154
     binary="./bin/${abi}/rt-migrate-test"
 fi
+
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
 "${binary}" -p "${PRIORITY}" -D "${DURATION}" -c | tee "${LOGFILE}"
+
+background_process_stop bgcmd
 
 # Parse test log.
 task_num=$(grep "Task" "${LOGFILE}" | tail -1 | awk '{print $2}')

--- a/automated/linux/rt-migrate-test/rt-migrate-test.yaml
+++ b/automated/linux/rt-migrate-test/rt-migrate-test.yaml
@@ -25,11 +25,15 @@ metadata:
         - d05
 
 params:
+    # Priority of lowest prio thread (3 threads are created).
     PRIORITY: "96"
+    # Execute rt-migrate-test for given time
     DURATION: "5m"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/rt-migrate-test/
-        - ./rt-migrate-test.sh -p "${PRIORITY}" -D "${DURATION}"
+        - ./rt-migrate-test.sh -p "${PRIORITY}" -D "${DURATION}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/signaltest/signaltest.sh
+++ b/automated/linux/signaltest/signaltest.sh
@@ -12,18 +12,20 @@ PRIORITY="98"
 THREADS="2"
 MAX_LATENCY="100"
 DURATION="1m"
+BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-r runtime] [-p priority] [-t threads] [-m latency]" 1>&2
+    echo "Usage: $0 [-r runtime] [-p priority] [-t threads] [-m latency] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":p:t:D:m:" opt; do
+while getopts ":p:t:D:m:w:" opt; do
     case "${opt}" in
         p) PRIORITY="${OPTARG}" ;;
         t) THREADS="${OPTARG}" ;;
 	D) DURATION="${OPTARG}" ;;
 	m) MAX_LATENCY="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -32,14 +34,18 @@ done
 create_out_dir "${OUTPUT}"
 
 # Run signaltest.
-if ! binary=$(which signaltest); then
+if ! binary=$(command -v signaltest); then
     detect_abi
     # shellcheck disable=SC2154
     binary="./bin/${abi}/signaltest"
 fi
 
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
 "${binary}" -D "${DURATION}" -m -p "${PRIORITY}" -t "${THREADS}" \
     | tee "${LOGFILE}"
+
+background_process_stop bgcmd
 
 # Parse test log.
 ../../lib/parse_rt_tests_results.py signaltest "${LOGFILE}" "${MAX_LATENCY}" \

--- a/automated/linux/signaltest/signaltest.yaml
+++ b/automated/linux/signaltest/signaltest.yaml
@@ -34,9 +34,11 @@ params:
     # Maximal accepted latency in us
     # This value is device/kernel specific and needs to be set in the job!
     MAX_LATENCY: "100"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/signaltest
-        - ./signaltest.sh -D "${DURATION}" -p "${PRIORITY}" -t "${THREADS}" -m "${MAX_LATENCY}"
+        - ./signaltest.sh -D "${DURATION}" -p "${PRIORITY}" -t "${THREADS}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/sigwaittest/sigwaittest.sh
+++ b/automated/linux/sigwaittest/sigwaittest.sh
@@ -11,16 +11,18 @@ LOGFILE="${OUTPUT}/sigwaittest.log"
 RESULT_FILE="${OUTPUT}/result.txt"
 DURATION="5m"
 MAX_LATENCY="100"
+BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-D duration] [-m latency]" 1>&2
+    echo "Usage: $0 [-D duration] [-m latency] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:" opt; do
+while getopts ":D:m:w:" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
 	m) MAX_LATENCY="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -37,7 +39,11 @@ if ! binary=$(command -v sigwaittest); then
     binary="./bin/${abi}/sigwaittest"
 fi
 
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
 "${binary}" -t -a -p 98 -D "${DURATION}" | tee "${LOGFILE}"
+
+background_process_stop bgcmd
 
 # Parse test log.
 ../../lib/parse_rt_tests_results.py sigwaittest "${LOGFILE}" "${MAX_LATENCY}" \

--- a/automated/linux/sigwaittest/sigwaittest.yaml
+++ b/automated/linux/sigwaittest/sigwaittest.yaml
@@ -33,9 +33,11 @@ params:
     # Maximal accepted latency in us
     # This value is device/kernel specific and needs to be set in the job!
     MAX_LATENCY: "100"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/sigwaittest/
-        - ./sigwaittest.sh -D "${DURATION}" -m "${MAX_LATENCY}"
+        - ./sigwaittest.sh -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/svsematest/svsematest.sh
+++ b/automated/linux/svsematest/svsematest.sh
@@ -11,16 +11,18 @@ LOGFILE="${OUTPUT}/svsematest.log"
 RESULT_FILE="${OUTPUT}/result.txt"
 DURATION="5m"
 MAX_LATENCY="100"
+BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-D duration] [-m latency]" 1>&2
+    echo "Usage: $0 [-D duration] [-m latency] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:" opt; do
+while getopts ":D:m:w:" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
 	m) MAX_LATENCY="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -37,7 +39,11 @@ if ! binary=$(command -v svsematest); then
     binary="./bin/${abi}/svsematest"
 fi
 
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
 "${binary}" -t -a -p 98 -D "${DURATION}" | tee "${LOGFILE}"
+
+background_process_stop bgcmd
 
 # Parse test log.
 ../../lib/parse_rt_tests_results.py svsematest "${LOGFILE}" "${MAX_LATENCY}" \

--- a/automated/linux/svsematest/svsematest.yaml
+++ b/automated/linux/svsematest/svsematest.yaml
@@ -33,9 +33,11 @@ params:
     # Maximal accepted latency in us
     # This value is device/kernel specific and needs to be set in the job!
     MAX_LATENCY: "100"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/svsematest
-        - ./svsematest.sh -D "${DURATION}" -m "${MAX_LATENCY}"
+        - ./svsematest.sh -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
[This PR is based on add-new-rt-tests PR [#92])

As discussed on IRC here is my attempt to add a background command to the rt-tests.

My first idea to use just environment variable didn't really work out because test shell script don't run call standard hooks. So that's why I added to all tests the background-process-start/stop call.

Also the idea to call lava-background-process-start if available turned out to be a bit a hassle. Because we still need to track state if lava-background-process-start has been called. It looked pretty ugly so I decided to just replicate the whole code in lib.

I think the whole approach looks a bit bolted on. Though I don't have a clear idea how to solve it cleaner except adding some sort of standard hooks (which can be extended or test code injected) which are always called from all tests.