### PR TITLE
kselftest: lkft: add proc-pid-vm to skipfile

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -149,6 +149,19 @@ skiplist:
       - run_afpackettests
 
   - reason: >
+      proc: proc-pid-vm hangs on x86_64 running next
+    url: https://bugs.linaro.org/show_bug.cgi?id=5332
+    environments: all
+    boards:
+      - qemu_x86_64
+      - x86_64
+    branches:
+      - next
+      - mainline
+    tests:
+      - proc-pid-vm
+
+  - reason: >
       LKFT: arm64/arm: selftest sync_test hangs on 4.9
     url: https://bugs.linaro.org/show_bug.cgi?id=4080
     environments: production


### PR DESCRIPTION
https://bugs.linaro.org/show_bug.cgi?id=5332

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>