### PR TITLE
kselftests: x86 instead of x86_64 for skipgen

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -166,7 +166,7 @@ skiplist:
     environments: all
     boards:
       - qemu_x86_64
-      - x86_64
+      - x86
     branches:
       - next
       - mainline
@@ -242,7 +242,7 @@ skiplist:
     environments: all
     boards:
       - qemu_x86_64
-      - x86_64
+      - x86
     branches:
       - next
       - mainline
@@ -255,7 +255,7 @@ skiplist:
     environments: all
     boards:
       - qemu_x86_64
-      - x86_64
+      - x86
     branches:
       - next
       - mainline


### PR DESCRIPTION
Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>