### PR TITLE
kselftest: lkft: add xfrm_policy.sh to skipfile

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -151,6 +151,16 @@ skiplist:
       - udpgro.sh
 
   - reason: >
+      net: xfrm_policy.sh hangs on i386 running next
+    url: https://bugs.linaro.org/show_bug.cgi?id=5342
+    environments: all
+    boards:
+      - i386
+    branches: all
+    tests:
+      - xfrm_policy.sh
+
+  - reason: >
       net: run_afpackettests hangs on hikey running 4.19 mainline
     url: https://bugs.linaro.org/show_bug.cgi?id=4049
     environments: all


### PR DESCRIPTION
net: xfrm_policy.sh hangs on i386 running on next

https://bugs.linaro.org/show_bug.cgi?id=5342

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>