### PR TITLE
android boottime: use wait_boot_completed instead of wait_homescreen

### DIFF
--- a/automated/android/boottime/boottime.sh
+++ b/automated/android/boottime/boottime.sh
@@ -31,8 +31,8 @@ install_deps 'curl tar xz-utils usbutils' "${SKIP_INSTALL}"
 
 initialize_adb
 adb_root
-# wait till the launcher displayed
-wait_homescreen "${BOOT_TIMEOUT}"
+# wait till boot completed
+wait_boot_completed "${BOOT_TIMEOUT}"
 
 create_out_dir "${OUTPUT}"
 


### PR DESCRIPTION
as the launcher activity log is not printed in the logcat any more

Change-Id: Ia757ca5c9e9a7a63023e6ba6d55e3e6534d24b88
Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>