### PR TITLE
docker: git clone depth 1

### DIFF
--- a/automated/linux/docker-integration-test/local-daemon.sh
+++ b/automated/linux/docker-integration-test/local-daemon.sh
@@ -44,7 +44,7 @@ else
     fi
 fi
 
-git clone https://github.com/docker/docker-ce
+git clone --depth 1 --branch "${RELEASE}" https://github.com/docker/docker-ce
 cd docker-ce/components/engine/
 git checkout "${RELEASE}" -b "${RELEASE}-test"
 # Enable shell xtrace and continue on test failure.


### PR DESCRIPTION
The docker-ce repo is clones to provide access to the files, not the
history in the repo.

Using '--depth 1' will speed up the clone and also uses less memory:
useful on resource constrained systems.

When making a shallow clone, you also want to specify the branch/tag you
require, because it most likely will not be available after the clone
completes.

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>