### PR TITLE
docker: hello-world support

### DIFF
--- a/automated/linux/docker/docker.sh
+++ b/automated/linux/docker/docker.sh
@@ -49,5 +49,12 @@ skip_list="run-docker-image"
 systemctl start docker
 exit_on_fail "start-docker-service" "${skip_list}"
 
-docker run -it "${IMAGE}" /bin/echo "Hello Docker"
+case "${IMAGE}" in
+    hello-world)
+        docker run "${IMAGE}"
+        ;;
+    *)
+        docker run -it "${IMAGE}" /bin/echo "Hello Docker"
+        ;;
+esac
 check_return "run-docker-image"


### PR DESCRIPTION
Add support for running the "hello-world" sample image to the docker
test.

This image requires fewer resources than an ubuntu system running a
shell command.

To run hello-world, the caller passes in "hello-world" for the IMAGE
parameter.

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>