### PR TITLE
kselftest: updating 5.3 branch for skipfile

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -29,6 +29,7 @@ skiplist:
     boards: all
     branches:
       - mainline
+      - 5.3
       - 5.2
       - 5.1
       - 4.19


### PR DESCRIPTION
Adding 5.3 stable rc branch to skipfile to skip ftracetest.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>