### PR TITLE
igt: get Chamelium IP address from shell environment variable

### DIFF
--- a/automated/linux/igt/igt-chamelium-test.yaml
+++ b/automated/linux/igt/igt-chamelium-test.yaml
@@ -45,4 +45,3 @@ run:
         - echo "************ Upload dump frames *************";
         - echo "*********************************************";
         - ${UPLOAD_TOOL} -a "dump-frames.tar.gz" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"; fi; fi
-        - ../../utils/send-to-lava.sh result.log

--- a/automated/linux/igt/igt-chamelium-test.yaml
+++ b/automated/linux/igt/igt-chamelium-test.yaml
@@ -15,7 +15,6 @@ metadata:
         - x15
 
 params:
-    CHAMELIUM_IP: "192.168.29.200"
     HDMI_DEV_NAME: "HDMI-A-1"
     IGT_DIR: "/igt-gpu-tools"
     # If TEST_LIST is not assigned, it will generate it with all
@@ -31,6 +30,7 @@ run:
         - cd ./automated/linux/igt
         - git config --global http.sslverify false
         - if [ -n "${TEST_LIST}" ]; then TL="-t ${TEST_LIST}"; fi
+        # ${CHAMELIUM_IP} is from LAVA device dictionary
         - ./igt-chamelium-test.sh -c ${CHAMELIUM_IP} -h ${HDMI_DEV_NAME} -d ${IGT_DIR} ${TL}
         # Dump igt test result and upload artifact to Artifactorial
         - ifconfig; pwd; ls -l


### PR DESCRIPTION
Now we already have LAVA support allowing test shell to query device
dictionary. So the DUT can get the paired Chamelium IP address from
shell environment variable ${CHAMELIUM_STATIC_IP}

Signed-off-by: Arthur She <arthur.she@linaro.org>