### PR TITLE
automated/android: fix apk-automation installation error

### DIFF
--- a/automated/android/apk-automation/apk-automation.sh
+++ b/automated/android/apk-automation/apk-automation.sh
@@ -39,8 +39,8 @@ if [ "${SKIP_INSTALL}" = "true" ] || [ "${SKIP_INSTALL}" = "True" ]; then
     info_msg "Package installation skipped"
 else
     ! check_root && error_msg "Please run this script as superuser!"
-    install_deps "git python python-lxml python-pil python-setuptools python-requests ca-certificates curl tar xz-utils" "${SKIP_INSTALL}"
-    git clone https://github.com/dtmilano/AndroidViewClient
+    install_deps "git python python-lxml python-pil python-setuptools python-requests python-matplotlib python-requests ca-certificates curl tar xz-utils" "${SKIP_INSTALL}"
+    git clone --depth 1 https://github.com/dtmilano/AndroidViewClient
     (
     cd AndroidViewClient/ || exit
     python setup.py install

--- a/automated/android/apk-automation/common/__init__.py
+++ b/automated/android/apk-automation/common/__init__.py
@@ -9,7 +9,10 @@ import shutil
 import subprocess
 import sys
 import time
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 from com.dtmilano.android.viewclient import ViewClient
 
 


### PR DESCRIPTION
New version of matplotlib requires python3. This patch makes sure that
python2 version of matplotlib is installed

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>