### PR TITLE
automated/linux: classify UNRESOLVED as fail

### DIFF
--- a/automated/linux/ltp-open-posix/ltp-open-posix.sh
+++ b/automated/linux/ltp-open-posix/ltp-open-posix.sh
@@ -57,7 +57,7 @@ parse_ltp_output() {
          | sed 's/://g; s/PASS/pass/'  >> "${RESULT_FILE}"
       grep -E ": FAILED|: SKIPPED|: UNSUPPORTED|: UNTESTED|: UNRESOLVED|: HUNG"  logfile."${EACH_TEST}"-test \
          | awk '{print $(NF-3)" "$(NF-1)}' \
-         | sed 's/://g; s/FAILED/fail/; s/SKIPPED/skip/; s/UNSUPPORTED/skip/; s/UNTESTED/skip/; s/UNRESOLVED/skip/; s/HUNG/skip/'  >> "${RESULT_FILE}"
+         | sed 's/://g; s/FAILED/fail/; s/SKIPPED/skip/; s/UNSUPPORTED/skip/; s/UNTESTED/skip/; s/UNRESOLVED/fail/; s/HUNG/skip/'  >> "${RESULT_FILE}"
     done
 
 }


### PR DESCRIPTION
Open Posix test suite may report test result as UNRESOLVED. This might
mean ABI break and should be classified as FAIL in test-definitions
convention.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>