### PR TITLE
automated/linux/workload-automation: Add ability to skip upgrade pip

### DIFF
--- a/automated/linux/workload-automation/workload-automation.sh
+++ b/automated/linux/workload-automation/workload-automation.sh
@@ -19,9 +19,10 @@ usage() {
     exit 1
 }
 
-while getopts ":s:t:r:T:c:a:o:R:D:d:" opt; do
+while getopts ":s:u:t:r:T:c:a:o:R:D:d:" opt; do
     case "${opt}" in
         s) SKIP_INSTALL="${OPTARG}" ;;
+        u) SKIP_UPGRADE_PIP_SETUPTOOLS="${OPTARG}" ;;
         t) WA_TAG="${OPTARG}" ;;
         r) WA_TEMPLATES_REPO="${OPTARG}" ;;
         T) TEMPLATES_BRANCH="${OPTARG}" ;;
@@ -51,8 +52,12 @@ if [ "${SKIP_INSTALL}" = "true" ] || [ "${SKIP_INSTALL}" = "True" ]; then
 else
     PKGS="git wget zip tar xz-utils python python-yaml python-lxml python-setuptools python-numpy python-colorama python-pip sqlite3 time sysstat openssh-client openssh-server sshpass python-jinja2 curl"
     install_deps "${PKGS}"
-    pip install --upgrade --quiet pip && hash -r
-    pip install --upgrade --quiet setuptools
+    if [ "${SKIP_UPGRADE_PIP_SETUPTOOLS}" = "true" ] || [ "${SKIP_UPGRADE_PIP_SETUPTOOLS}" = "True" ]; then
+        info_msg "Upgrade PIP skipped"
+    else
+        pip install --upgrade --quiet pip && hash -r
+        pip install --upgrade --quiet setuptools
+    fi
     pip install --quiet pexpect pyserial pyyaml docutils python-dateutil
     info_msg "Installing devlib..."
     rm -rf devlib

--- a/automated/linux/workload-automation/workload-automation.sh
+++ b/automated/linux/workload-automation/workload-automation.sh
@@ -40,7 +40,7 @@ done
 
 ! check_root && error_msg "Please run this test as root."
 cd "${TEST_DIR}"
-if [ ! -z "${NEW_OUTPUT}" ]; then
+if [ -n "${NEW_OUTPUT}" ]; then
     OUTPUT="${NEW_OUTPUT}"
 fi
 create_out_dir "${OUTPUT}"

--- a/automated/linux/workload-automation/workload-automation.yaml
+++ b/automated/linux/workload-automation/workload-automation.yaml
@@ -20,6 +20,7 @@ metadata:
 
 params:
     SKIP_INSTALL: "false"
+    SKIP_UPGRADE_PIP_SETUPTOOLS: "false"
     # Params for WA test run.
     WA_TAG: "master"
     WA_GIT_REPO: "https://github.com/ARM-software/workload-automation"
@@ -50,7 +51,7 @@ run:
         - if [ -z "${OUTPUT}" ]; then OUTPUT="./output"; fi
         - echo ${OUTPUT}
         # Test run.
-        - ./workload-automation.sh -s "${SKIP_INSTALL}" -t "${WA_TAG}" -r "${WA_TEMPLATES_REPO}" -T "${TEMPLATES_BRANCH}" -c "${CONFIG}" -a "${AGENDA}" -R "${WA_GIT_REPO}" -d "${DEVLIB_REPO}" -D "${DEVLIB_TAG}" -o "${OUTPUT}"
+        - ./workload-automation.sh -s "${SKIP_INSTALL}" -u "${SKIP_UPGRADE_PIP_SETUPTOOLS}" -t "${WA_TAG}" -r "${WA_TEMPLATES_REPO}" -T "${TEMPLATES_BRANCH}" -c "${CONFIG}" -a "${AGENDA}" -R "${WA_GIT_REPO}" -d "${DEVLIB_REPO}" -D "${DEVLIB_TAG}" -o "${OUTPUT}"
         # Upload test output to artifactorial.
         - tar caf "wa-output.tar.xz" "${OUTPUT}"
         - ../../utils/upload-to-artifactorial.sh -a "wa-output.tar.xz" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"


### PR DESCRIPTION
It is causing problems because new pip versions (10.x) has a bug when
dealing with distutil packages. [1]

[1] https://github.com/pypa/pip/issues/5247

Change-Id: Ifdd9322dc507907b6347d26478a04a890dec6fed
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>