### PR TITLE
automated/linux: Use tags for 2.x in workload-automation

### DIFF
--- a/automated/linux/workload-automation/workload-automation.yaml
+++ b/automated/linux/workload-automation/workload-automation.yaml
@@ -21,11 +21,11 @@ metadata:
 params:
     SKIP_INSTALL: "false"
     # Params for WA test run.
-    WA_TAG: "master"
+    WA_TAG: "v2.7.0"
     WA_GIT_REPO: "https://github.com/ARM-software/workload-automation"
     # Install devlib, which is WA depenency
     DEVLIB_REPO: "https://github.com/ARM-software/devlib.git"
-    DEVLIB_TAG: "master"
+    DEVLIB_TAG: "v1.1.2"
     WA_TEMPLATES_REPO: "https://git.linaro.org/qa/wa2-lava.git"
     TEMPLATES_BRANCH: "wa-templates"
     CONFIG: "config/generic-linux-localhost.py"


### PR DESCRIPTION
We have a workload-automation3 testdef so this one is target to use
the version 2 of the tool use proper tags by default.

Change-Id: I9121a14772fe59d750c68d97c59fb2f3ab481004
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>