### PR TITLE
tradefed and noninteractive-tradefed: install different openjdk version

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -6,6 +6,12 @@
 . ../../lib/android-test-lib
 
 JDK="openjdk-8-jdk-headless"
+if [ -n "${ANDROID_VERSION}" ] && echo "${ANDROID_VERSION}" | grep -q  "aosp-master"; then
+    # only use openjdk-11 for aosp master version
+    JDK="openjdk-11-jdk-headless"
+#elif 8.1/9.0/android10
+#   JDK="openjdk-8-jdk-headless"
+fi
 
 PKG_DEPS="coreutils usbutils curl wget zip xz-utils python-lxml python-setuptools python-pexpect aapt lib32z1-dev libc6-dev-i386 lib32gcc1 libc6:i386 libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 python-dev python-protobuf protobuf-compiler python-virtualenv python-pip python-pexpect psmisc"
 

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -34,9 +34,10 @@ params:
     # Specify the failures number to be printed
     FAILURES_PRINTED: "0"
     TEST_REBOOT_EXPECTED: "false"
-    # leave ANDROID_VERSION here as a stub so that jobs have ANDROID_VERSION specified won't report any problem
-    # but it is not used any more, the default openjdk-8 will be used for cts/vts test
-    # and in the future, maybe the jdk package installation is better to be done with the host deploy action
+    # used to specify the android version
+    # as different jdk version might be used for different android version cts/vts test
+    # aosp-master version needs to use openjdk-11, other older versions needs to use openjdk-8
+    # for aosp master version, the value of ANDROID_VERSION must have aosp-master in its value
     ANDROID_VERSION: ""
 
 run:

--- a/automated/android/tradefed/setup.sh
+++ b/automated/android/tradefed/setup.sh
@@ -6,7 +6,14 @@
 . ../../lib/android-test-lib
 
 JDK="openjdk-8-jdk-headless"
-PKG_DEPS="usbutils curl wget zip xz-utils python-lxml python-setuptools python-pexpect aapt lib32z1-dev libc6-dev-i386 lib32gcc1 libc6:i386 libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 python-dev python-protobuf protobuf-compiler python-virtualenv python-pip python-pexpect psmisc"
+if [ -n "${ANDROID_VERSION}" ] && echo "${ANDROID_VERSION}" | grep -q  "aosp-master"; then
+    # only use openjdk-11 for aosp master version
+    JDK="openjdk-11-jdk-headless"
+#elif 8.1/9.0/android10
+#   JDK="openjdk-8-jdk-headless"
+fi
+
+PKG_DEPS="coreutils usbutils curl wget zip xz-utils python-lxml python-setuptools python-pexpect aapt lib32z1-dev libc6-dev-i386 lib32gcc1 libc6:i386 libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 python-dev python-protobuf protobuf-compiler python-virtualenv python-pip python-pexpect psmisc"
 
 dist_name
 case "${dist}" in

--- a/automated/android/tradefed/tradefed.yaml
+++ b/automated/android/tradefed/tradefed.yaml
@@ -34,9 +34,10 @@ params:
     # Specify the failures number to be printed
     FAILURES_PRINTED: "0"
     TEST_REBOOT_EXPECTED: "false"
-    # leave ANDROID_VERSION here as a stub so that jobs have ANDROID_VERSION specified won't report any problem
-    # but it is not used any more, the default openjdk-8 will be used for cts/vts test
-    # and in the future, maybe the jdk package installation is better to be done with the host deploy action
+    # used to specify the android version
+    # as different jdk version might be used for different android version cts/vts test
+    # aosp-master version needs to use openjdk-11, other older versions needs to use openjdk-8
+    # for aosp master version, the value of ANDROID_VERSION must have aosp-master in its value
     ANDROID_VERSION: ""
 
 run:


### PR DESCRIPTION
for different android version cts/vts test.

Now only aosp master version needs to use openjdk-11,
other older versions need to use openjdk8

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>