### PR TITLE
kselftests: skip rtnetlink.sh on all devices

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -276,8 +276,7 @@ skiplist:
     url: https://bugs.linaro.org/show_bug.cgi?id=5339
     environments: all
     boards:
-      - qemu_i386
-      - i386
+      - all
     branches:
       - all
     tests:


### PR DESCRIPTION
selftests net rtnetlink.sh test hangs intermittently on all devices and which
is blocking other tests to run. So skipping rtnetlink.sh tests.

ref:
https://bugs.linaro.org/show_bug.cgi?id=5339

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>