### PR TITLE
kvm-unit-tests: run all test with option a

### DIFF
--- a/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
+++ b/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
@@ -44,9 +44,9 @@ parse_output() {
 kvm_unit_tests_run_test() {
     info_msg "running kvm unit tests ..."
     if [ "${SMP}" = "false" ]; then
-        taskset -c 0 ./run_tests.sh -v | tee -a "${RESULT_LOG}"
+        taskset -c 0 ./run_tests.sh -a -v | tee -a "${RESULT_LOG}"
     else
-        ./run_tests.sh -v | tee -a "${RESULT_LOG}"
+        ./run_tests.sh -a -v | tee -a "${RESULT_LOG}"
     fi
 }
 


### PR DESCRIPTION
As per the kvm unit tests author it is recommended to run tests
with option -a to enable and run all tests.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>