### PR TITLE
igt: power cycle Chamelium once it is unreachable

### DIFF
--- a/automated/linux/igt/control_chamelium.sh
+++ b/automated/linux/igt/control_chamelium.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+delay=10
+SNMPSET="/usr/bin/snmpset"
+CONTROL_OID=".1.3.6.1.4.1.318.1.1.4.4.2.1.3."
+
+usage() {
+    printf "usage: control-chamelium.py [-h] --hostname HOSTNAME --port PORT --command
+                            {off,on,reboot} [--delay DELAY]\n
+optional arguments:
+  -h, --help            show this help message and exit
+  --hostname HOSTNAME   The pdu you wish to control - e.g. pdu05
+  --port PORT           The pdu port you wish to control, e.g. 4 or 15
+  --command {off,on,reboot}
+                        What you wish to do with the port 'off', 'on',
+                        'reboot'
+  --delay DELAY         Delay in seconds when rebooting between power off and
+                        power on (default 10 seconds)\n"
+}
+
+send_command() {
+    control_oid="${CONTROL_OID}${port}"
+    echo "Turn ${hostname} port ${port} $1"
+    if [ "$1" = "on" ]; then
+        cmd="1"
+    else
+        cmd="2"
+    fi
+
+    ${SNMPSET} -v 1 -c private "${hostname}" "${control_oid}" i "${cmd}"
+}
+
+while [ $# -gt 0 ]
+do
+    key="$1"
+
+    case $key in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --hostname)
+            hostname="$2"
+            shift
+            shift
+            ;;
+        --port)
+            port="$2"
+            shift
+            shift
+            ;;
+        --command)
+            command="$2"
+            shift
+            shift
+            ;;
+        --delay)
+            delay="$2"
+            shift
+            shift
+            ;;
+        *)
+            usage
+            exit 0
+            ;;
+    esac 
+done
+
+if [ -z "${hostname}" ] || [ -z "${port}" ] || [ -z "${command}" ]; then
+    usage
+    exit 1
+fi
+if [ "${command}" != "off" ] && [ "${command}" != "on" ] && [ "${command}" != "reboot" ]; then
+    usage
+    exit 1
+fi
+
+if [ "${command}" = "reboot" ]; then
+    send_command "off"
+    sleep "${delay}"
+    send_command "on"
+else
+    send_command "${command}"
+fi

--- a/automated/linux/igt/igt-test.yaml
+++ b/automated/linux/igt/igt-test.yaml
@@ -21,15 +21,27 @@ params:
     TEST_LIST: "CHAMELIUM"
     ARTIFACTORIAL_URL: ""
     ARTIFACTORIAL_TOKEN: ""
+    CHAMELIUM_PING_RETRY: 2
 
 run:
     steps:
         - cd ./automated/linux/igt
+        # Check if Chamelium is available
+        - while [ ${CHAMELIUM_PING_RETRY} -gt 0 ]; do PC=`ping -c 2 ${CHAMELIUM_IP}|grep '100% packet loss'`||true; if [ -n "${PC}" ]; then ./control_chamelium.sh ${CHAMELIUM_REBOOT_ARG}; sleep 30; (( CHAMELIUM_PING_RETRY-- )); else break; fi; done
+        - test ${CHAMELIUM_PING_RETRY} -gt 0 && lava-test-case "Ping-Chamelium" --result pass || lava-test-raise "Ping-Chamelium"
         - OPT="-d ${IGT_DIR} -t ${TEST_LIST}"
+        # Check Chamelium uboot console status
+        - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CHAMELIUM_IP} /usr/bin/lock_u_boot_console
+        # Showing the uptime of Chamelium
+        - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CHAMELIUM_IP} /usr/bin/uptime
         # ${CHAMELIUM_IP} is from LAVA device dictionary
         - if [ -n "${CHAMELIUM_IP}" ]; then OPT="${OPT} -c ${CHAMELIUM_IP}"; fi
         - if [ -n "${HDMI_DEV_NAME}" ]; then OPT="${OPT} -h ${HDMI_DEV_NAME}"; fi
         - ./igt-test.sh ${OPT}
+        # Delete Chameliumd log
+        - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CHAMELIUM_IP} /usr/bin/uptime
+        - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CHAMELIUM_IP} sh -c "echo '' > /var/log/chameleond"
+        - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CHAMELIUM_IP} sh -c "echo '' > /var/log/chameleond_init"
         # Dump igt test result and upload artifact to Artifactorial
         - ifconfig; pwd; ls -l
         - echo "**********************************************";


### PR DESCRIPTION
1. Power cycle the Chamelium once we don't get the ping response from it
    (snmpset from Net-SNMP is required)
2. Check uboot console lock status and uptime of the Chamelium
3. Delete chameliumd log after each test

Signed-off-by: Arthur She <arthur.she@linaro.org>