### PR TITLE
smoke.sh: use # as sed delimiter

### DIFF
--- a/automated/linux/smoke/smoke.sh
+++ b/automated/linux/smoke/smoke.sh
@@ -47,5 +47,5 @@ install
 while [ -n "${TESTS}" ]; do
     test_cmd="$(echo "${TESTS}" | awk -F',' '{print $1}')"
     run "${test_cmd}"
-    TESTS="$(echo "${TESTS}" | sed -r "s/${test_cmd},? *//")"
+    TESTS="$(echo "${TESTS}" | sed -r "s#${test_cmd},? *##")"
 done


### PR DESCRIPTION
This allows the test commands to contain '/' characters, eg:

  ./smoke.sh -t "cat /proc/cpuinfo"

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>