### PR TITLE
iperf: split into client and server

### DIFF
--- a/automated/linux/iperf/iperf-client.yaml
+++ b/automated/linux/iperf/iperf-client.yaml
@@ -4,12 +4,13 @@ metadata:
     description: "iperf is a tool for active measurements of the maximum
                   achievable bandwidth on IP networks."
     maintainer:
-        - chase.qi@linaro.org
+        - milosz.wasilewski@linaro.org
     os:
         - debian
         - ubuntu
         - fedora
         - centos
+        - openembedded
     scope:
         - performance
     environment:
@@ -22,29 +23,29 @@ metadata:
         - thunderX
         - d03
         - d05
+        - soca9
+        - rzn1d
 
 params:
     # Time in seconds to transmit for
     TIME: "10"
     # Number of parallel client streams to run
     THREADS: "1"
+    # Set affinity of the client to cpu 0 using "-A 0"
+    AFFINITY: ""
+    # Set REVERSE="-R" to run tx from the server
+    REVERSE: ""
     SKIP_INSTALL: "false"
-    # Specify iperf server
-    # Set the var to lava-host-role for test run with LAVA multinode job
-    SERVER: 127.0.0.1
     # When running with LAVA multinode job, set the following vars to the values
-    # sent by lava-send from host role.
+    # sent by lava-send from server role.
     MSG_ID: server-ready
     MSG_KEY: ipaddr
 
 run:
     steps:
-        - fixed_server="${SERVER}"
-        - if [ "${SERVER}" = "lava-host-role" ]; then
-        -     lava-wait "${MSG_ID}"
-        -     fixed_server=$(grep "${MSG_KEY}" /tmp/lava_multi_node_cache.txt | awk -F"=" '{print $NF}')
-        - fi
+        - lava-wait "${MSG_ID}"
+        - server=$(grep "${MSG_KEY}" /tmp/lava_multi_node_cache.txt | awk -F"=" '{print $NF}')
         - cd ./automated/linux/iperf/
-        - ./iperf.sh -t "${TIME}" -p "${THREADS}" -s "${SKIP_INSTALL}" -c "${fixed_server}"
+        - ./iperf.sh -t "${TIME}" -p "${THREADS}" -s "${SKIP_INSTALL}" -c "${server}" "${AFFINITY}" "${REVERSE}"
         - ../../utils/send-to-lava.sh ./output/result.txt
-        - '[ "${SERVER}" = "lava-host-role" ] && lava-send client-done'
+        - lava-send client-done

--- a/automated/linux/iperf/iperf-server.yaml
+++ b/automated/linux/iperf/iperf-server.yaml
@@ -1,0 +1,41 @@
+metadata:
+    name: iperf
+    format: "Lava-Test-Shell Test Definition 1.0"
+    description: "iperf is a tool for active measurements of the maximum
+                  achievable bandwidth on IP networks."
+    maintainer:
+        - milosz.wasilewski@linaro.org
+    os:
+        - debian
+        - ubuntu
+        - fedora
+        - centos
+        - openembedded
+    scope:
+        - performance
+    environment:
+        - lava-test-shell
+    devices:
+        - hi6220-hikey
+        - apq8016-sbc
+        - mustang
+        - moonshot
+        - thunderX
+        - d03
+        - d05
+        - soca9
+        - rzn1d
+
+params:
+    SKIP_INSTALL: "false"
+    SERVER_ETHERNET_DEVICE: "eth0"
+
+run:
+    steps:
+        - cd ./automated/linux/iperf/
+        - ipaddr=$(lava-echo-ipv4 ${SERVER_ETHERNET_DEVICE} | tr -d '\0')
+        - if [ -z "${ipaddr}" ]; then echo lava-test-raise "${SERVER_ETHERNET_DEVICE} not found"; fi
+        - lava-send server-ready ipaddr=${ipaddr}
+        - ./iperf.sh -s "${SKIP_INSTALL}"
+        - lava-wait client-done
+        - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/iperf/iperf.sh
+++ b/automated/linux/iperf/iperf.sh
@@ -5,27 +5,34 @@
 OUTPUT="$(pwd)/output"
 RESULT_FILE="${OUTPUT}/result.txt"
 LOGFILE="${OUTPUT}/iperf.txt"
-# Test localhost by default, which tests the efficiency of TCP/IP stack.
-# To test physical network bandwidth, specify remote test server with '-c'.
-# Execute 'iperf3 -s' on remote host to run iperf3 test server.
-SERVER="127.0.0.1"
+# If SERVER is blank, we are the server, otherwise
+# If we are the client, we set SERVER to the ipaddr of the server
+SERVER=""
 # Time in seconds to transmit for
 TIME="10"
 # Number of parallel client streams to run
 THREADS="1"
 # Specify iperf3 version for CentOS.
 VERSION="3.1.4"
+# By default, the client sends to the server,
+# Setting REVERSE="-R" means the server sends to the client
+REVERSE=""
+# CPU affinity is blank by default, meaning no affinity.
+# CPU numbers are zero based, eg AFFINITY="-A 0" for the first CPU
+AFFINITY=""
 
 usage() {
-    echo "Usage: $0 [-c server] [-t time] [-p number] [-v version] [-s true|false]" 1>&2
+    echo "Usage: $0 [-c server] [-t time] [-p number] [-v version] [-A cpu affinity] [-R] [-s true|false]" 1>&2
     exit 1
 }
 
-while getopts "c:t:p:v:s:h" o; do
+while getopts "A:c:t:p:v:s:Rh" o; do
   case "$o" in
+    A) AFFINITY="-A ${OPTARG}" ;;
     c) SERVER="${OPTARG}" ;;
     t) TIME="${OPTARG}" ;;
     p) THREADS="${OPTARG}" ;;
+    R) REVERSE="-R" ;;
     v) VERSION="${OPTARG}" ;;
     s) SKIP_INSTALL="${OPTARG}" ;;
     h|*) usage ;;
@@ -57,22 +64,31 @@ else
 fi
 
 # Run local iperf3 server as a daemon when testing localhost.
-[ "${SERVER}" = "127.0.0.1" ] && iperf3 -s -D
+if [ "${SERVER}" = "" ]; then
+    # We are running in server mode.
+    # Start the server and report pass/fail
+    cmd="iperf3 -s -D"
+    ${cmd}
+    if pgrep -f "${cmd}" > /dev/null; then
+        result="pass"
+    else
+        result="fail"
+    fi
+    echo "iperf3_server_started ${result}" | tee -a "${RESULT_FILE}"
+else
+    # We are running in client mode
+    # Run iperf test with unbuffered output mode.
+    stdbuf -o0 iperf3 -c "${SERVER}" -t "${TIME}" -P "${THREADS}" "${REVERSE}" "${AFFINITY}" 2>&1 \
+        | tee "${LOGFILE}"
 
-# Run iperf test with unbuffered output mode.
-stdbuf -o0 iperf3 -c "${SERVER}" -t "${TIME}" -P "${THREADS}" 2>&1 \
-    | tee "${LOGFILE}"
-
-# Parse logfile.
-if [ "${THREADS}" -eq 1 ]; then
-    grep -E "(sender|receiver)" "${LOGFILE}" \
-        | awk '{printf("iperf-%s pass %s %s\n", $NF,$7,$8)}' \
-        | tee -a "${RESULT_FILE}"
-elif [ "${THREADS}" -gt 1 ]; then
-    grep -E "[SUM].*(sender|receiver)" "${LOGFILE}" \
-        | awk '{printf("iperf-%s pass %s %s\n", $NF,$6,$7)}' \
-        | tee -a "${RESULT_FILE}"
+    # Parse logfile.
+    if [ "${THREADS}" -eq 1 ]; then
+        grep -E "(sender|receiver)" "${LOGFILE}" \
+            | awk '{printf("iperf_%s pass %s %s\n", $NF,$7,$8)}' \
+            | tee -a "${RESULT_FILE}"
+    elif [ "${THREADS}" -gt 1 ]; then
+        grep -E "[SUM].*(sender|receiver)" "${LOGFILE}" \
+            | awk '{printf("iperf_%s pass %s %s\n", $NF,$6,$7)}' \
+            | tee -a "${RESULT_FILE}"
+    fi
 fi
-
-# Kill iperf test daemon if any.
-pkill iperf3 || true

--- a/automated/linux/iperf/lava-multinode-job-example-iperf.yaml
+++ b/automated/linux/iperf/lava-multinode-job-example-iperf.yaml
@@ -10,17 +10,17 @@ priority: medium
 visibility: public
 
 metadata:
-  ipef-version: v3
+  iperf-version: v3
 
 protocols:
   lava-multinode:
     roles:
-      host:
+      server:
         device_type: beaglebone-black
         count: 1
         timeout:
           minutes: 30
-      guest:
+      client:
         device_type: beaglebone-black
         count: 1
         timeout:
@@ -29,7 +29,7 @@ protocols:
 actions:
 - deploy:
     role:
-      - host
+      - server
     timeout:
       minutes: 4
     to: tftp
@@ -53,7 +53,7 @@ actions:
 
 - deploy:
     role:
-      - guest
+      - client
     timeout:
       minutes: 4
     to: tftp
@@ -77,7 +77,7 @@ actions:
 
 - boot:
     role:
-      - host
+      - server
     method: u-boot
     commands: nfs
     auto_login:
@@ -90,7 +90,7 @@ actions:
 
 - boot:
     role:
-      - guest
+      - client
     method: u-boot
     commands: nfs
     auto_login:
@@ -103,40 +103,32 @@ actions:
 
 - test:
     role:
-    - host
-    timeout:
-      minutes: 30
-    definitions:
-    - repository:
-        metadata:
-          format: Lava-Test Test Definition 1.0
-          name: run-iperf3-server
-          description: "Run iperf3 in server mode"
-        run:
-          steps:
-          - apt-get -y update
-          - apt-get -y install iperf3
-          - if iperf3 -s -D; then lava-test-case run-iperf3-server --result 'pass'; else lava-test-raise 'Failed to run ipef3 server'; fi
-          - lava-send server-ready ipaddr=$(lava-echo-ipv4 eth0)
-          - lava-wait client-done
-          - pkill iperf3
-      from: inline
-      name: run-iperf3-server
-      path: inline/run-iperf3-server.yaml
-
-- test:
-    role:
-    - guest
+    - server
     timeout:
       minutes: 30
     definitions:
     - repository: https://github.com/Linaro/test-definitions.git
       branch: master
       from: git
-      path: automated/linux/iperf/iperf.yaml
+      path: automated/linux/iperf/iperf-server.yaml
       name: iperf3-test
       parameters:
-        SERVER: lava-host-role
+        SERVER_ETHERNET_DEVICE: eth0
+
+- test:
+    role:
+    - client
+    timeout:
+      minutes: 30
+    definitions:
+    - repository: https://github.com/Linaro/test-definitions.git
+      branch: master
+      from: git
+      path: automated/linux/iperf/iperf-client.yaml
+      name: iperf3-test
+      parameters:
+        AFFINITY: ""
+        REVERSE: ""
         # The MSG ID and KEY should be the same as the ones sent by lava-send above
         MSG_ID: server-ready
         MSG_KEY: ipaddr


### PR DESCRIPTION
Split the iperf.sh script so it runs as either server of client, but not
both.

If the caller wishes to run the test with a local server, they must
invoke the script twice.

This commit also creates a YAML for the server.

Additional parameters are added to the client to allow CPU affinity, or
to reverse the test, so the client is the receiver instead of the
transmitter.

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>