### PR TITLE
iperf: move lava commands into iperf.sh

### DIFF
--- a/automated/linux/iperf/iperf-client.yaml
+++ b/automated/linux/iperf/iperf-client.yaml
@@ -27,6 +27,9 @@ metadata:
         - rzn1d
 
 params:
+    # Set the location of the server.
+    # When running in LAVA, it will attempt to discover the server address
+    SERVER: "localhost"
     # Time in seconds to transmit for
     TIME: "10"
     # Number of parallel client streams to run
@@ -36,16 +39,9 @@ params:
     # Set REVERSE="-R" to run tx from the server
     REVERSE: ""
     SKIP_INSTALL: "false"
-    # When running with LAVA multinode job, set the following vars to the values
-    # sent by lava-send from server role.
-    MSG_ID: server-ready
-    MSG_KEY: ipaddr
 
 run:
     steps:
-        - lava-wait "${MSG_ID}"
-        - server=$(grep "${MSG_KEY}" /tmp/lava_multi_node_cache.txt | awk -F"=" '{print $NF}')
         - cd ./automated/linux/iperf/
-        - ./iperf.sh -t "${TIME}" -p "${THREADS}" -s "${SKIP_INSTALL}" -c "${server}" "${AFFINITY}" "${REVERSE}"
+        - ./iperf.sh -c "${SERVER}" -t "${TIME}" -p "${THREADS}" -s "${SKIP_INSTALL}" "${AFFINITY}" "${REVERSE}"
         - ../../utils/send-to-lava.sh ./output/result.txt
-        - lava-send client-done

--- a/automated/linux/iperf/iperf-server.yaml
+++ b/automated/linux/iperf/iperf-server.yaml
@@ -33,9 +33,5 @@ params:
 run:
     steps:
         - cd ./automated/linux/iperf/
-        - ipaddr=$(lava-echo-ipv4 ${SERVER_ETHERNET_DEVICE} | tr -d '\0')
-        - if [ -z "${ipaddr}" ]; then echo lava-test-raise "${SERVER_ETHERNET_DEVICE} not found"; fi
-        - lava-send server-ready ipaddr=${ipaddr}
-        - ./iperf.sh -s "${SKIP_INSTALL}"
-        - lava-wait client-done
+        - ./iperf.sh -s "${SKIP_INSTALL}" -e "${SERVER_ETHERNET_DEVICE}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/iperf/lava-multinode-job-example-iperf.yaml
+++ b/automated/linux/iperf/lava-multinode-job-example-iperf.yaml
@@ -129,6 +129,3 @@ actions:
       parameters:
         AFFINITY: ""
         REVERSE: ""
-        # The MSG ID and KEY should be the same as the ones sent by lava-send above
-        MSG_ID: server-ready
-        MSG_KEY: ipaddr


### PR DESCRIPTION
Rather than run the LAVA commands in the YAML, run them in the script.

This is particularly useful so that installation happens before the lava-wait.
This helps prevent timeouts on slower platforms.

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>