### PR TITLE
docs: add tags

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,3 +4,7 @@ repo_url: https://github.com/linaro/test-definitions
 copyright: Linaro Ltd.
 plugins:
     - linaro-test-definitions
+    - tags
+    - exclude:
+        glob:
+          - plans/*

--- a/mkdocs_plugin/requirements.txt
+++ b/mkdocs_plugin/requirements.txt
@@ -1,2 +1,4 @@
 mkdocs-test-definitions-plugin
 mdutils
+git+https://github.com/mwasilew/mkdocs-plugin-tags.git
+mkdocs-exclude

--- a/mkdocs_plugin/setup.py
+++ b/mkdocs_plugin/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mkdocs-test-definitions-plugin',
-    version='1.0.1',
+    version='1.1.0',
     description='An MkDocs plugin that converts LAVA test definitions to documentation',
     long_description='',
     keywords='mkdocs python markdown wiki',
@@ -13,7 +13,7 @@ setup(
     license='GPL',
     python_requires='>=3.5',
     install_requires=[
-        'mkdocs>=1'
+        'mkdocs>=1.1'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This patch will add 'tags' top nav bar item to the mkdocs page. The tags
are collected from the metadata 'scope' list in each test.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>