### PR TITLE
kselftest: skip ftracetest on stable-rc branches 5.4, 5.6 and 5.7

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -29,9 +29,9 @@ skiplist:
     boards: all
     branches:
       - mainline
-      - 5.3
-      - 5.2
-      - 5.1
+      - 5.7
+      - 5.6
+      - 5.4
       - 4.19
       - 4.14
       - 4.9


### PR DESCRIPTION
Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>