### PR TITLE
Some improvement on the tradefed  test

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed-runner.py
+++ b/automated/android/noninteractive-tradefed/tradefed-runner.py
@@ -49,7 +49,12 @@ def result_parser(xml_file, result_format):
                 or 0x10000 <= num <= 0x10FFFF):
             etree_content = etree_content[:mstart] + etree_content[mend:]
             endpos = len(etree_content)
-        pos = mend
+            # next time search again from the same position as this time
+            # as the detected pattern was removed here
+            pos = mstart
+        else:
+            # continue from the end of this match
+            pos = mend
 
     try:
         root = ET.fromstring(etree_content)

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -53,7 +53,7 @@ run:
         - chown testuser:testuser .
         - if echo "${TEST_REBOOT_EXPECTED}" |grep -i "true" ; then ./monitor_fastboot.sh & fi
         - ./monitor_adb.sh &
-        - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}"
+        - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}" || true
         # Upload test log and result files to artifactorial.
         - cp -r ./${TEST_PATH}/results ./output/ || true
         - cp -r ./${TEST_PATH}/logs ./output/ || true

--- a/automated/android/tradefed/result_parser.py
+++ b/automated/android/tradefed/result_parser.py
@@ -57,7 +57,12 @@ class TradefedResultParser:
             ):
                 etree_content = etree_content[:mstart] + etree_content[mend:]
                 endpos = len(etree_content)
-            pos = mend
+                # next time search again from the same position as this time
+                # as the detected pattern was removed here
+                pos = mstart
+            else:
+                # continue from the end of this match
+                pos = mend
 
         try:
             root = ET.fromstring(etree_content)


### PR DESCRIPTION
1. fixed the problem that not all xml un-support characters removed.
2. continue to try to upload the result/log files to archive site even the tradefed test itself failed.

Test job which get the result successfully:
https://validation.linaro.org/scheduler/job/2048126

The old jobs:
https://validation.linaro.org/scheduler/job/2045998 failed to get the result successfully
https://validation.linaro.org/scheduler/job/2045733 not have the attachment uploaded
