### PR TITLE
yaml.load fix

### DIFF
--- a/plans/testplan2html.py
+++ b/plans/testplan2html.py
@@ -102,7 +102,7 @@ def test_exists(test, repositories, args):
     os.chdir(current_dir)
     print os.getcwd()
     test_file = open(test_file_path, "r")
-    test_yaml = yaml.load(test_file.read())
+    test_yaml = yaml.load(test_file.read(), Loader=yaml.FullLoader)
     params_string = ""
     if 'parameters' in test.keys():
         params_string = "_".join(["{0}-{1}".format(param_name, param_value).replace("/", "").replace(" ", "") for param_name, param_value in test['parameters'].iteritems()])
@@ -239,7 +239,7 @@ def main():
     for testplan in args.testplan_list:
         if os.path.exists(testplan) and os.path.isfile(testplan):
             testplan_file = open(testplan, "r")
-            tp_obj = yaml.load(testplan_file.read())
+            tp_obj = yaml.load(testplan_file.read(), Loader=yaml.FullLoader)
             repo_list = repository_list(tp_obj)
             repositories = {}
             for repo in repo_list:


### PR DESCRIPTION
Fixes the following warning when calling yaml.load

testplan2html.py:243: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>