### PR TITLE
kselftest: check for run script

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -144,7 +144,7 @@ else
     fi
     tar zxf "kselftest.tar.gz"
     # shellcheck disable=SC2164
-    cd "kselftest"
+    if [ ! -e "run_kselftest.sh" ]; then cd "kselftest"; fi
 fi
 
 if [ -n "${SKIPLIST}" ]; then


### PR DESCRIPTION
The kselftest.sh wrapper currently assumes that the kselftest tarball
was created with a top-level "kselftest" directory, which builds
in an assumption about how the tarball was created.

To fix, test to see if the top-level run-script is present in the
current dir before trying to "cd kselftest"

Signed-off-by: Kevin Hilman <khilman@baylibre.com>