### PR TITLE
kselftest: add ip to install_deps

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -117,8 +117,8 @@ install() {
     dist_name
     # shellcheck disable=SC2154
     case "${dist}" in
-        debian|ubuntu) install_deps "sed wget xz-utils" "${SKIP_INSTALL}" ;;
-        centos|fedora) install_deps "sed wget xz" "${SKIP_INSTALL}" ;;
+        debian|ubuntu) install_deps "sed wget xz-utils iproute2" "${SKIP_INSTALL}" ;;
+        centos|fedora) install_deps "sed wget xz iproute" "${SKIP_INSTALL}" ;;
         unknown) warn_msg "Unsupported distro: package install skipped" ;;
     esac
 }


### PR DESCRIPTION
Lots of kselftests depend on the 'ip' tool.