### PR TITLE
armnn-unit-tests: creating test definitions for armnn unit tests

### DIFF
--- a/automated/linux/armnn/armnn-unit-tests.sh
+++ b/automated/linux/armnn/armnn-unit-tests.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+
+usage() {
+    echo "Usage: $0 [-s <true|false>]" 1>&2
+    exit 1
+}
+
+while getopts "s:a:d:" o; do
+  case "$o" in
+    s) SKIP_INSTALL="${OPTARG}" ;;
+    a) ARMNN_TARBALL="${OPTARG}" ;;
+    d) TEST_DIR="${OPTARG}" ;;
+    *) usage ;;
+  esac
+done
+
+! check_root && error_msg "You need to be root to run this script."
+create_out_dir "${OUTPUT}"
+
+pkgs="ntp wget gcc g++ python3 python3-pip"
+dhclient
+install_deps "${pkgs}" "${SKIP_INSTALL}"
+
+if [[-n ${ARMNN_TARBALL} ]]; then
+    mkdir -p ${TEST_DIR}
+    cd ${TEST_DIR}
+    wget -O armnn.tar.xz "${ARMNN_TARBALL}"
+    tar xf armnn.tar.xz
+    export BASEDIR="/home/buildslave/workspace/armnn-ci-build"
+fi
+
+if [[ ${SKIP_INSTALL} == false ]]; then
+    cd $BASEDIR/build
+    ln -s libprotobuf.so.15.0.0 ./libprotobuf.so.15
+    export LD_LIBRARY_PATH=`pwd`
+    chmod a+x UnitTests
+fi
+lava-test-case ArmNN-Unit-Tests --shell ./UnitTests

--- a/automated/linux/armnn/armnn-unit-tests.yaml
+++ b/automated/linux/armnn/armnn-unit-tests.yaml
@@ -1,0 +1,25 @@
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: armnn-unit-tests
+    description: "Carry out armnn unit tests."
+    maintainer:
+        - theodore.grey@linaro.org
+    os:
+        - debian
+    scope:
+        - functional
+    devices:
+        - synquacer
+        - dragonboard-845c
+        - hi960-hikey
+        - stm32mp1
+params:
+    # if you need to run for 32 bit devices use:
+    # 'https://snapshots.linaro.org/componenets/armnn-32bit/latest/armnn-32.tar.xz'
+    ARMNN_TARBALL: 'https://snapshots.linaro.org/componenets/armnn/latest/armnn.tar.xz'
+    TEST_DIR: '/usr/local/bin'
+    SKIP_INSTALL: false
+run:
+    steps:
+        - cd ./automated/linux/armnn/
+        - ./armnn-unit-tests.sh -s "${SKIP_INSTALL}" -a "${ARMNN_TARBALL}" -d "{TEST_DIR}"


### PR DESCRIPTION
automated: linux: add the armnn unit tests

Adding armnn-unit-tests files to automated/linux/armnn/ in order to facilitate deployment to 64bit and 32bit devices in the LAVA lab as part of the armnn ci loop. This will deploy Deploy ArmNN as well as it's build UnitTests to a board which does not already contain them. If a board already has ArmNN installed it will also allow for the UnitTests to be automated and run. 

Signed-off-by: Theodore Grey <theodore.grey@linaro.org>