### PR TITLE
igt: Check Chamelium IP address before we go further

### DIFF
--- a/automated/linux/igt/igt-test.yaml
+++ b/automated/linux/igt/igt-test.yaml
@@ -28,14 +28,13 @@ run:
         - cd ./automated/linux/igt
         - OPT="-d ${IGT_DIR} -t ${TEST_LIST}"
         - if [ "${TEST_LIST}" = "CHAMELIUM" ]; then
-        # Check if Chamelium is available
+        # Check if Chamelium is available. ${CHAMELIUM_IP} is from LAVA device dictionary
         - while [ ${CHAMELIUM_PING_RETRY} -gt 0 ]; do PC=`ping -c 2 ${CHAMELIUM_IP}|grep '100% packet loss'`||true; if [ -n "${PC}" ]; then ./control_chamelium.sh ${CHAMELIUM_REBOOT_ARG}; sleep 30; (( CHAMELIUM_PING_RETRY-- )); else break; fi; done
-        - test ${CHAMELIUM_PING_RETRY} -gt 0 && lava-test-case "Ping-Chamelium" --result pass || lava-test-raise "Ping-Chamelium"
+        - test -n "${CHAMELIUM_IP}" && test ${CHAMELIUM_PING_RETRY} -gt 0 && lava-test-case "Ping-Chamelium" --result pass || lava-test-raise "Ping-Chamelium"
         # Check Chamelium uboot console status
-        - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CHAMELIUM_IP} /usr/bin/lock_u_boot_console
+        - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CHAMELIUM_IP} /usr/bin/lock_u_boot_console || true
         # Showing the uptime of Chamelium
-        - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CHAMELIUM_IP} /usr/bin/uptime
-        # ${CHAMELIUM_IP} is from LAVA device dictionary
+        - ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@${CHAMELIUM_IP} /usr/bin/uptime || true
         - if [ -n "${CHAMELIUM_IP}" ]; then OPT="${OPT} -c ${CHAMELIUM_IP}"; fi
         - if [ -n "${HDMI_DEV_NAME}" ]; then OPT="${OPT} -h ${HDMI_DEV_NAME}"; fi
         - fi


### PR DESCRIPTION
The Chamelium IP address comes from device dict. It has to be ready
before we do the further tests.

Signed-off-by: Arthur She <arthur.she@linaro.org>