### PR TITLE
cyclictest: use quiet output

### DIFF
--- a/automated/linux/cyclictest/cyclictest.sh
+++ b/automated/linux/cyclictest/cyclictest.sh
@@ -43,7 +43,7 @@ if ! binary=$(which cyclictest); then
     # shellcheck disable=SC2154
     binary="./bin/${abi}/cyclictest"
 fi
-"${binary}" -p "${PRIORITY}" -i "${INTERVAL}" -t "${THREADS}" -a "${AFFINITY}" \
+"${binary}" -q -p "${PRIORITY}" -i "${INTERVAL}" -t "${THREADS}" -a "${AFFINITY}" \
     -D "${DURATION}" -m | tee "${LOGFILE}"
 
 # Parse test log.


### PR DESCRIPTION
cyclictest output is meant for interactive terminals.  On dumb
terminals, it creates lots of noise resulting in massive logs.

Use quiet output (-q) to silence and just print a summary at the end
of the test.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>