### PR TITLE
rt-tests: Remove MAX_LATENCY argument

### DIFF
--- a/automated/lib/parse_rt_tests_results.py
+++ b/automated/lib/parse_rt_tests_results.py
@@ -29,13 +29,8 @@ import re
 import sys
 
 
-def print_res(res, key, thr):
-    val = res[key]
-    label = 'pass'
-    if key == 'max':
-        if int(val) >= int(thr):
-            label = 'fail'
-    print('t{}-{}-latency {} {} us'.format(res['t'], key, label, val))
+def print_res(res, key):
+    print('t{}-{}-latency pass {} us'.format(res['t'], key, res[key]))
 
 
 def get_block(filename):
@@ -76,7 +71,7 @@ def get_lastlines(filename):
         return b.split('\n')
 
 
-def parse_cyclictest(filename, thr):
+def parse_cyclictest(filename):
     fields = ['t', 'min', 'avg', 'max']
 
     r = re.compile('[ :\n]+')
@@ -91,12 +86,12 @@ def parse_cyclictest(filename, thr):
             if e in fields:
                 res[e] = next(it)
 
-        print_res(res, 'min', thr)
-        print_res(res, 'avg', thr)
-        print_res(res, 'max', thr)
+        print_res(res, 'min')
+        print_res(res, 'avg')
+        print_res(res, 'max')
 
 
-def parse_pmqtest(filename, thr):
+def parse_pmqtest(filename):
     fields = ['min', 'avg', 'max']
 
     rl = re.compile('[ ,:\n]+')
@@ -117,17 +112,18 @@ def parse_pmqtest(filename, thr):
         data = rt.split(line)
         res['t'] = '{}-{}'.format(data[1], data[3])
 
-        print_res(res, 'min', thr)
-        print_res(res, 'avg', thr)
-        print_res(res, 'max', thr)
+        print_res(res, 'min')
+        print_res(res, 'avg')
+        print_res(res, 'max')
 
 
 def main():
     tool = sys.argv[1]
+    logfile = sys.argv[2]
     if tool in ['cyclictest', 'signaltest', 'cyclicdeadline']:
-        parse_cyclictest(sys.argv[2], int(sys.argv[3]))
+        parse_cyclictest(logfile)
     elif tool in ['pmqtest', 'ptsematest', 'sigwaittest', 'svsematest']:
-        parse_pmqtest(sys.argv[2], int(sys.argv[3]))
+        parse_pmqtest(logfile)
 
 
 if __name__ == '__main__':

--- a/automated/linux/cyclicdeadline/cyclicdeadline.sh
+++ b/automated/linux/cyclicdeadline/cyclicdeadline.sh
@@ -14,21 +14,19 @@ INTERVAL="1000"
 STEP="500"
 THREADS="1"
 DURATION="1m"
-MAX_LATENCY="50"
 BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-i interval] [-s step] [-t threads] [-D duration ] [-m latency] [-w background_cmd]" 1>&2
+    echo "Usage: $0 [-i interval] [-s step] [-t threads] [-D duration ] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":i:s:t:D:m:w:" opt; do
+while getopts ":i:s:t:D:w:" opt; do
     case "${opt}" in
         i) INTERVAL="${OPTARG}" ;;
 	s) STEP="${STEP}" ;;
         t) THREADS="${OPTARG}" ;;
         D) DURATION="${OPTARG}" ;;
-	m) MAX_LATENCY="${OPTARG}" ;;
 	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
@@ -52,5 +50,5 @@ background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 background_process_stop bgcmd
 
 # Parse test log.
-../../lib/parse_rt_tests_results.py cyclicdeadline "${LOGFILE}" "${MAX_LATENCY}" \
+../../lib/parse_rt_tests_results.py cyclicdeadline "${LOGFILE}" \
     | tee -a "${RESULT_FILE}"

--- a/automated/linux/cyclicdeadline/cyclicdeadline.yaml
+++ b/automated/linux/cyclicdeadline/cyclicdeadline.yaml
@@ -36,14 +36,11 @@ params:
     THREADS: "1"
     # Execute cyclicdeadline for given time
     DURATION: "5m"
-    # Maximal accepted latency in us
-    # This value is device/kernel specific and needs to be set in the job!
-    MAX_LATENCY: "50"
     # Background workload to be run during the meassurement
     BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/cyclicdeadline/
-        - ./cyclicdeadline.sh -i "${INTERVAL}" -s "${STEP}" -t "${THREADS}" -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
+        - ./cyclicdeadline.sh -i "${INTERVAL}" -s "${STEP}" -t "${THREADS}" -D "${DURATION}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/cyclictest/cyclictest.sh
+++ b/automated/linux/cyclictest/cyclictest.sh
@@ -15,22 +15,20 @@ INTERVAL="1000"
 THREADS="1"
 AFFINITY="0"
 DURATION="1m"
-MAX_LATENCY="50"
 BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-p priority] [-i interval] [-t threads] [-a affinity] [-D duration ] [-m latency] [-w background_cmd]" 1>&2
+    echo "Usage: $0 [-p priority] [-i interval] [-t threads] [-a affinity] [-D duration ] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":p:i:t:a:D:m:w:" opt; do
+while getopts ":p:i:t:a:D:w:" opt; do
     case "${opt}" in
         p) PRIORITY="${OPTARG}" ;;
         i) INTERVAL="${OPTARG}" ;;
         t) THREADS="${OPTARG}" ;;
 	a) AFFINITY="${OPTARG}" ;;
         D) DURATION="${OPTARG}" ;;
-	m) MAX_LATENCY="${OPTARG}" ;;
 	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
@@ -54,5 +52,5 @@ background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 background_process_stop bgcmd
 
 # Parse test log.
-../../lib/parse_rt_tests_results.py cyclictest "${LOGFILE}" "${MAX_LATENCY}" \
+../../lib/parse_rt_tests_results.py cyclictest "${LOGFILE}" \
     | tee -a "${RESULT_FILE}"

--- a/automated/linux/cyclictest/cyclictest.yaml
+++ b/automated/linux/cyclictest/cyclictest.yaml
@@ -38,14 +38,11 @@ params:
     AFFINITY: "0"
     # Execute cyclictest for given time
     DURATION: "5m"
-    # Maximal accepted latency in us
-    # This value is device/kernel specific and needs to be set in the job!
-    MAX_LATENCY: "50"
     # Background workload to be run during the meassurement
     BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/cyclictest/
-        - ./cyclictest.sh -D "${DURATION}" -p "${PRIORITY}" -i "${INTERVAL}" -t "${THREADS}" -a "${AFFINITY}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
+        - ./cyclictest.sh -D "${DURATION}" -p "${PRIORITY}" -i "${INTERVAL}" -t "${THREADS}" -a "${AFFINITY}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/pmqtest/pmqtest.sh
+++ b/automated/linux/pmqtest/pmqtest.sh
@@ -9,18 +9,16 @@ OUTPUT="${TEST_DIR}/output"
 LOGFILE="${OUTPUT}/pmqtest.log"
 RESULT_FILE="${OUTPUT}/result.txt"
 DURATION="5m"
-MAX_LATENCY="100"
 BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-D duration] [-m latency] [-w background_cmd]" 1>&2
+    echo "Usage: $0 [-D duration] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:w:" opt; do
+while getopts ":D:w:" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
-	m) MAX_LATENCY="${OPTARG}" ;;
 	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
@@ -45,5 +43,5 @@ background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 background_process_stop bgcmd
 
 # Parse test log.
-../../lib/parse_rt_tests_results.py pmqtest "${LOGFILE}" "${MAX_LATENCY}" \
+../../lib/parse_rt_tests_results.py pmqtest "${LOGFILE}" \
     | tee -a "${RESULT_FILE}"

--- a/automated/linux/pmqtest/pmqtest.yaml
+++ b/automated/linux/pmqtest/pmqtest.yaml
@@ -27,14 +27,11 @@ metadata:
 
 params:
     DURATION: "5m"
-    # Maximal accepted latency in us
-    # This value is device/kernel specific and needs to be set in the job!
-    MAX_LATENCY: "100"
     # Background workload to be run during the meassurement
     BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/pmqtest/
-        - ./pmqtest.sh -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
+        - ./pmqtest.sh -D "${DURATION}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ptsematest/ptsematest.sh
+++ b/automated/linux/ptsematest/ptsematest.sh
@@ -8,18 +8,16 @@ OUTPUT="${TEST_DIR}/output"
 LOGFILE="${OUTPUT}/ptsematest.log"
 RESULT_FILE="${OUTPUT}/result.txt"
 DURATION="5m"
-MAX_LATENCY="100"
 BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-D duration] [-m latency] [-w background_cmd]" 1>&2
+    echo "Usage: $0 [-D duration] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:w:" opt; do
+while getopts ":D:w:" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
-	m) MAX_LATENCY="${OPTARG}" ;;
 	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
@@ -44,5 +42,5 @@ background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 background_process_stop bgcmd
 
 # Parse test log.
-../../lib/parse_rt_tests_results.py ptsematest "${LOGFILE}" "${MAX_LATENCY}" \
+../../lib/parse_rt_tests_results.py ptsematest "${LOGFILE}" \
     | tee -a "${RESULT_FILE}"

--- a/automated/linux/ptsematest/ptsematest.yaml
+++ b/automated/linux/ptsematest/ptsematest.yaml
@@ -29,14 +29,11 @@ metadata:
 params:
     # Execute ptsematest for given time
     DURATION: "5m"
-    # Maximal accepted latency in us
-    # This value is device/kernel specific and needs to be set in the job!
-    MAX_LATENCY: "100"
     # Background workload to be run during the meassurement
     BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/ptsematest/
-        - ./ptsematest.sh -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
+        - ./ptsematest.sh -D "${DURATION}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/signaltest/signaltest.sh
+++ b/automated/linux/signaltest/signaltest.sh
@@ -10,21 +10,19 @@ RESULT_FILE="${OUTPUT}/result.txt"
 
 PRIORITY="98"
 THREADS="2"
-MAX_LATENCY="100"
 DURATION="1m"
 BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-r runtime] [-p priority] [-t threads] [-m latency] [-w background_cmd]" 1>&2
+    echo "Usage: $0 [-r runtime] [-p priority] [-t threads] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":p:t:D:m:w:" opt; do
+while getopts ":p:t:D:w:" opt; do
     case "${opt}" in
         p) PRIORITY="${OPTARG}" ;;
         t) THREADS="${OPTARG}" ;;
 	D) DURATION="${OPTARG}" ;;
-	m) MAX_LATENCY="${OPTARG}" ;;
 	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
@@ -48,5 +46,5 @@ background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 background_process_stop bgcmd
 
 # Parse test log.
-../../lib/parse_rt_tests_results.py signaltest "${LOGFILE}" "${MAX_LATENCY}" \
+../../lib/parse_rt_tests_results.py signaltest "${LOGFILE}" \
     | tee -a "${RESULT_FILE}"

--- a/automated/linux/signaltest/signaltest.yaml
+++ b/automated/linux/signaltest/signaltest.yaml
@@ -31,14 +31,11 @@ params:
     # Number of threads.
     THREADS: "2"
     DURATION: "1m"
-    # Maximal accepted latency in us
-    # This value is device/kernel specific and needs to be set in the job!
-    MAX_LATENCY: "100"
     # Background workload to be run during the meassurement
     BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/signaltest
-        - ./signaltest.sh -D "${DURATION}" -p "${PRIORITY}" -t "${THREADS}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
+        - ./signaltest.sh -D "${DURATION}" -p "${PRIORITY}" -t "${THREADS}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/sigwaittest/sigwaittest.sh
+++ b/automated/linux/sigwaittest/sigwaittest.sh
@@ -10,18 +10,16 @@ OUTPUT="${TEST_DIR}/output"
 LOGFILE="${OUTPUT}/sigwaittest.log"
 RESULT_FILE="${OUTPUT}/result.txt"
 DURATION="5m"
-MAX_LATENCY="100"
 BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-D duration] [-m latency] [-w background_cmd]" 1>&2
+    echo "Usage: $0 [-D duration] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:w:" opt; do
+while getopts ":D:w:" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
-	m) MAX_LATENCY="${OPTARG}" ;;
 	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
@@ -46,5 +44,5 @@ background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 background_process_stop bgcmd
 
 # Parse test log.
-../../lib/parse_rt_tests_results.py sigwaittest "${LOGFILE}" "${MAX_LATENCY}" \
+../../lib/parse_rt_tests_results.py sigwaittest "${LOGFILE}" \
     | tee -a "${RESULT_FILE}"

--- a/automated/linux/sigwaittest/sigwaittest.yaml
+++ b/automated/linux/sigwaittest/sigwaittest.yaml
@@ -30,14 +30,11 @@ metadata:
 params:
     # Execute sigwaittest for given time
     DURATION: "5m"
-    # Maximal accepted latency in us
-    # This value is device/kernel specific and needs to be set in the job!
-    MAX_LATENCY: "100"
     # Background workload to be run during the meassurement
     BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/sigwaittest/
-        - ./sigwaittest.sh -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
+        - ./sigwaittest.sh -D "${DURATION}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/svsematest/svsematest.sh
+++ b/automated/linux/svsematest/svsematest.sh
@@ -10,18 +10,16 @@ OUTPUT="${TEST_DIR}/output"
 LOGFILE="${OUTPUT}/svsematest.log"
 RESULT_FILE="${OUTPUT}/result.txt"
 DURATION="5m"
-MAX_LATENCY="100"
 BACKGROUND_CMD=""
 
 usage() {
-    echo "Usage: $0 [-D duration] [-m latency] [-w background_cmd]" 1>&2
+    echo "Usage: $0 [-D duration] [-w background_cmd]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:w:" opt; do
+while getopts ":D:w:" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
-	m) MAX_LATENCY="${OPTARG}" ;;
 	w) BACKGROUND_CMD="${OPTARG}" ;;
         *) usage ;;
     esac
@@ -46,5 +44,5 @@ background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 background_process_stop bgcmd
 
 # Parse test log.
-../../lib/parse_rt_tests_results.py svsematest "${LOGFILE}" "${MAX_LATENCY}" \
+../../lib/parse_rt_tests_results.py svsematest "${LOGFILE}" \
     | tee -a "${RESULT_FILE}"

--- a/automated/linux/svsematest/svsematest.yaml
+++ b/automated/linux/svsematest/svsematest.yaml
@@ -30,14 +30,11 @@ metadata:
 params:
     # Execute svsematest for given time
     DURATION: "5m"
-    # Maximal accepted latency in us
-    # This value is device/kernel specific and needs to be set in the job!
-    MAX_LATENCY: "100"
     # Background workload to be run during the meassurement
     BACKGROUND_CMD: ""
 
 run:
     steps:
         - cd ./automated/linux/svsematest
-        - ./svsematest.sh -D "${DURATION}" -m "${MAX_LATENCY}" -w "${BACKGROUND_CMD}"
+        - ./svsematest.sh -D "${DURATION}" -w "${BACKGROUND_CMD}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Remove the MAX_LATENCY argument again. It was not a good idea to mix execution/controlling of the test jobs and the performance measurement. This is done better in post processing. Rip it out again. I kept the parse_rt_tests_results.py for all rt-tests. The output format every test is slightly different and I was not able to get it working in a pure shell version. Until we have a better output format from upstream (yep planing to add this), let's stick with the current script.
