### PR TITLE
igt: Check target network status before go further

### DIFF
--- a/automated/linux/igt/igt-test.yaml
+++ b/automated/linux/igt/igt-test.yaml
@@ -27,7 +27,13 @@ run:
     steps:
         - cd ./automated/linux/igt
         - OPT="-d ${IGT_DIR} -t ${TEST_LIST}"
+        # Check if the network is available
+        - ifconfig
+        - ping -c 2 www.google.com || lava-test-raise "Target-network-failed"
         - if [ "${TEST_LIST}" = "CHAMELIUM" ]; then
+        # Reboot Chamelium
+        - echo -e "\nReboot the chamelium\n"
+        - ./control_chamelium.sh ${CHAMELIUM_REBOOT_ARG}; sleep 30
         # Check if Chamelium is available. ${CHAMELIUM_IP} is from LAVA device dictionary
         - while [ ${CHAMELIUM_PING_RETRY} -gt 0 ]; do PC=`ping -c 2 ${CHAMELIUM_IP}|grep '100% packet loss'`||true; if [ -n "${PC}" ]; then ./control_chamelium.sh ${CHAMELIUM_REBOOT_ARG}; sleep 30; (( CHAMELIUM_PING_RETRY-- )); else break; fi; done
         - test -n "${CHAMELIUM_IP}" && test ${CHAMELIUM_PING_RETRY} -gt 0 && lava-test-case "Ping-Chamelium" --result pass || lava-test-raise "Ping-Chamelium"


### PR DESCRIPTION
Fix the test result will be misleading when the network is unavailable.
1. Stop testing if the network is not available
2. Power cycle Chamelium before running igt Chamelium test

Signed-off-by: Arthur She <arthur.she@linaro.org>