### PR TITLE
igt: Abort the test if the Chamelium can not be reboot

### DIFF
--- a/automated/linux/igt/control_chamelium.sh
+++ b/automated/linux/igt/control_chamelium.sh
@@ -66,6 +66,10 @@ do
     esac 
 done
 
+if [ -z "$(ls ${SNMPSET})" ]; then
+    echo "Can not find ${SNMPSET}"
+    exit 1
+fi
 if [ -z "${hostname}" ] || [ -z "${port}" ] || [ -z "${command}" ]; then
     usage
     exit 1

--- a/automated/linux/igt/igt-test.yaml
+++ b/automated/linux/igt/igt-test.yaml
@@ -33,7 +33,7 @@ run:
         - if [ "${TEST_LIST}" = "CHAMELIUM" ]; then
         # Reboot Chamelium
         - echo -e "\nReboot the chamelium\n"
-        - ./control_chamelium.sh ${CHAMELIUM_REBOOT_ARG}; sleep 30
+        - ./control_chamelium.sh ${CHAMELIUM_REBOOT_ARG} || lava-test-raise "CAN-NOT-reboot-Chamelium"; sleep 30
         # Check if Chamelium is available. ${CHAMELIUM_IP} is from LAVA device dictionary
         - while [ ${CHAMELIUM_PING_RETRY} -gt 0 ]; do PC=`ping -c 2 ${CHAMELIUM_IP}|grep '100% packet loss'`||true; if [ -n "${PC}" ]; then ./control_chamelium.sh ${CHAMELIUM_REBOOT_ARG}; sleep 30; (( CHAMELIUM_PING_RETRY-- )); else break; fi; done
         - test -n "${CHAMELIUM_IP}" && test ${CHAMELIUM_PING_RETRY} -gt 0 && lava-test-case "Ping-Chamelium" --result pass || lava-test-raise "Ping-Chamelium"


### PR DESCRIPTION
NetSNMP is required for igt Chamelium test to power cycle the Chamelium.
If it is not included in the test image, the test will be failed without
any clear hint. This patch will raise the error "CAN-NOT-reboot-Chamelium"
and abort the test if the Chamelium can not be reoot.

Signed-off-by: Arthur She <arthur.she@linaro.org>