### PR TITLE
linux: bootrr: Move into cloned repo before executing test

### DIFF
--- a/automated/linux/bootrr/bootrr.yaml
+++ b/automated/linux/bootrr/bootrr.yaml
@@ -28,5 +28,6 @@ run:
         - . ./automated/lib/sh-test-lib
         - install_deps git "${SKIP_INSTALL}"
         - git clone https://github.com/andersson/bootrr
+        - cd bootrr
         - export PATH=$PWD/helpers:$PATH
         - ./boards/${BOARD}


### PR DESCRIPTION
Currently bootrr tests are not executed as we are not moving into the
cloned repository. Fix it!

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>