### PR TITLE
kselftest: skip hang test case ptrace vmaccess

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -312,3 +312,25 @@ skiplist:
       - all
     tests:
       - pidfd/pidfd_wait
+  - reason: >
+      ptrace vmaccess hangs on all devices on stable rc 4.19 branch and lower
+      kernel versions
+    url: https://bugs.linaro.org/show_bug.cgi?id=5683
+    environments: all
+    boards:
+      - all
+    branches:
+      - 4.4
+      - 4.9
+      - 4.14
+      - 4.19
+      - linux-4.4.y
+      - linux-4.9.y
+      - linux-4.14.y
+      - linux-4.19.y
+      - v4.4-rt
+      - v4.9-rt
+      - v4.14-rt
+      - v4.19-rt
+    tests:
+      - ptrace/vmaccess


### PR DESCRIPTION
ptrace vmaccess hangs on all devices on stable rc 4.19 branch and
lower kernel versions

ref:
https://bugs.linaro.org/show_bug.cgi?id=5683


Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>