### PR TITLE
test-runner: make sure the measurement is a number

### DIFF
--- a/automated/utils/test-runner.py
+++ b/automated/utils/test-runner.py
@@ -758,7 +758,10 @@ class ResultParser(object):
                         if result_match:
                             data['result'] = result_match.group(1)
                         if measurement_match:
-                            data['measurement'] = measurement_match.group(1)
+                            try:
+                                data['measurement'] = float(measurement_match.group(1))
+                            except ValueError as e:
+                                pass
                         if units_match:
                             data['units'] = units_match.group(1)
 


### PR DESCRIPTION
In one of our tests, we had:
openssl-speed,openssl-version,pass,1.1.1g,version,SKIP_INSTALL=False

And when submitting to Squad, it failed because the measurement was
not a 'number' (e.g. 1.1.1g). With this patch, we make sure that all
measurements reported to Squad are integers or float.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>