### PR TITLE
linux: wlan-download: Always ping google.com

### DIFF
--- a/automated/linux/wlan-download/wlan-download-test.sh
+++ b/automated/linux/wlan-download/wlan-download-test.sh
@@ -91,8 +91,7 @@ test_wlan_connection() {
 # test WLAN download
 test_wlan_download() {
     info_msg "Running wlan download test..."
-    hostname="$(echo "${FILE_URL}" | sed 's/.*:\/\///;s|\/.*||')"
-    ping -c 4 "${hostname}"
+    ping -c 4 www.google.com
     check_return "wlan-ping"
     curl -OL --interface "${DEVICE}" "${FILE_URL}"
     check_return "wlan-download"


### PR DESCRIPTION
Currently the test case extracts hostname from FILE_URL and tries to ping it.
But due to the server configuration, "testdata.validation.linaro.org" is not
accepting ping requests now. So, let's use google.com statically to ping. This
will rule out possible ping issues in future also.

Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>