### PR TITLE
test-runner: add support for test-case-id for manual tests

### DIFF
--- a/automated/utils/test-runner.py
+++ b/automated/utils/test-runner.py
@@ -434,14 +434,15 @@ class RemoteTestRun(AutomatedTestRun):
 
 
 class ManualTestShell(cmd.Cmd):
-    def __init__(self, test_dict, result_path):
+    def __init__(self, test_dict, result_path, test_case_id):
         cmd.Cmd.__init__(self)
         self.test_dict = test_dict
+        self.test_case_id = test_case_id
         self.result_path = result_path
         self.current_step_index = 0
         self.steps = self.test_dict['run']['steps']
         self.expected = self.test_dict['run']['expected']
-        self.prompt = "%s > " % self.test_dict['metadata']['name']
+        self.prompt = "%s[%s] > " % (self.test_dict['metadata']['name'], self.test_case_id)
         self.result = None
         self.intro = """
         Welcome to manual test executor. Type 'help' for available commands.
@@ -508,7 +509,7 @@ class ManualTestShell(cmd.Cmd):
         print("Recording %s in %s/stdout.log" % (result, self.result_path))
         with open("%s/stdout.log" % self.result_path, "a") as f:
             f.write("<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=%s RESULT=%s>" %
-                    (self.test_dict['metadata']['name'], result))
+                    (self.test_case_id, result))
 
     def do_pass(self, line):
         """
@@ -541,7 +542,12 @@ class ManualTestRun(TestRun, cmd.Cmd):
         with open('%s/testdef.yaml' % self.test['test_path'], 'r') as f:
             self.testdef = yaml.safe_load(f)
 
-        ManualTestShell(self.testdef, self.test['test_path']).cmdloop()
+        if 'name' in self.test:
+            test_case_id = self.test['name']
+        else:
+            test_case_id = self.testdef['metadata']['name']
+
+        ManualTestShell(self.testdef, self.test['test_path'], test_case_id).cmdloop()
 
     def check_result(self):
         pass


### PR DESCRIPTION
A manual test in the test plan runs a single test case, and we expect
a single result/metric. However test definitions in general are
typically made as series of test cases from a test suite.

It might be useful to run several test cases from a single manual test
suite. This patch adds a test_case_id attribute for manual test cases.

The test_case_id attrivute is set to the test suite name by
default. However when using the same test definition multiple times in
a test plan, we can override the test_case_id attribute from the test
plan, using a custom 'name'.

Here is an example of such a test plan:

  manual:
    - path: manual/generic/96boards-ls-gpio.yaml
      repository: https://git.linaro.org/qa/test-definitions.git
      name: gpio-A
    - path: manual/generic/96boards-ls-gpio.yaml
      repository: https://git.linaro.org/qa/test-definitions.git
      name: gpio-B
    - path: manual/generic/96boards-ls-gpio.yaml
      repository: https://git.linaro.org/qa/test-definitions.git
      name: gpio-C
    - path: manual/generic/96boards-ls-i2c.yaml
      repository: https://git.linaro.org/qa/test-definitions.git
      name: i2c0
    - path: manual/generic/96boards-ls-i2c.yaml
      repository: https://git.linaro.org/qa/test-definitions.git
      name: i2c1

This test plan indicates that we want to run the manual test
96boards-ls-gpio and 96boards-ls-i2c multiple times, and we provide a
different name (e.g. test_case_id) each time. The test description can
say something like "if test_case_id is defined, it indicates which
GPIO to test".

Running this test plan with this patch can create:

name,test_case_id,result,measurement,units,test_params
96boards-ls-gpio,gpio-A,pass,,,
96boards-ls-gpio,gpio-B,fail,,,
96boards-ls-gpio,gpio-C,skip,,,
96boards-ls-gpio,i2c0,pass,,,
96boards-ls-gpio,i2c1,pass,,,

To make it clear to the tester, this patch modifies the prompt to
show:

test_suite_name[test_case_id] /

A full execution log is:

{'path': 'manual/generic/96boards-ls-gpio.yaml', 'repository': 'https://git.linaro.org/qa/test-definitions.git', 'name': 'gpio-A', 'uuid': '76cc444d-7696-40d0-9bfd-1fb7d88d7888'}
{'path': 'manual/generic/96boards-ls-gpio.yaml', 'repository': 'https://git.linaro.org/qa/test-definitions.git', 'name': 'gpio-B', 'uuid': 'd14ad66c-9118-46c6-9bc7-e90ac23eb08c'}
{'path': 'manual/generic/96boards-ls-gpio.yaml', 'repository': 'https://git.linaro.org/qa/test-definitions.git', 'name': 'gpio-C', 'uuid': '3040b01c-0f2a-402b-b26d-9454c0c2004f'}
{'path': 'manual/generic/96boards-ls-i2c.yaml', 'repository': 'https://git.linaro.org/qa/test-definitions.git', 'name': 'i2c0', 'uuid': '779cc339-2379-4f18-ae0a-714f3f73c3e0'}
{'path': 'manual/generic/96boards-ls-i2c.yaml', 'repository': 'https://git.linaro.org/qa/test-definitions.git', 'name': 'i2c1', 'uuid': '3860c63c-3f5c-4379-84cb-b3d76da9c3b3'}
2020-10-07 23:44:32,051 - RUNNER.TestSetup: INFO: Test repo copied to: /home/ndec/output/96boards-ls-gpio_76cc444d-7696-40d0-9bfd-1fb7d88d7888
96boards-ls-gpio

        Welcome to manual test executor. Type 'help' for available commands.
        This shell is meant to be executed on your computer, not on the system
        under test. Please execute the steps from the test case, compare to
        expected result and record the test result as 'pass' or 'fail'. If there
        is an issue that prevents from executing the step, please record the result
        as 'skip'.

96boards-ls-gpio[96boards-ls-gpio-A] > pass
Recording pass in /home/ndec/output/96boards-ls-gpio_76cc444d-7696-40d0-9bfd-1fb7d88d7888/stdout.log

--- Printing result.csv ---
name,test_case_id,result,measurement,units,test_params
96boards-ls-gpio,96boards-ls-gpio-A,pass,,,
...
...

Alternatively, we could add support for 'parameters' in manual tests,
and use 'params' to pass test attributes from the test plan, e.g.

  manual:
    - path: manual/generic/96boards-ls-gpio.yaml
      repository: https://git.linaro.org/qa/test-definitions.git
      name: 96boards-ls-gpio-A
      params:
          GPIO: A
    - path: manual/generic/96boards-ls-gpio.yaml
      repository: https://git.linaro.org/qa/test-definitions.git
      name: 96boards-ls-gpio-B
      params:
          GPIO: B
    - path: manual/generic/96boards-ls-gpio.yaml
      repository: https://git.linaro.org/qa/test-definitions.git
      name: 96boards-ls-gpio-C
      params:
          GPIO: C

I just wanted to have a simple patch to start with..

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>