### PR TITLE
boottime.yaml: remove the passing of ANDROID_SERIAL

### DIFF
--- a/automated/android/boottime/boottime.sh
+++ b/automated/android/boottime/boottime.sh
@@ -1,7 +1,6 @@
 #!/bin/sh -e
 # shellcheck disable=SC1091
 
-ANDROID_SERIAL=""
 BOOT_TIMEOUT="300"
 OPERATION="COLLECT"
 COLLECT_NO="1"
@@ -12,14 +11,13 @@ SKIP_INSTALL='true'
 . ../../lib/android-test-lib
 
 usage() {
-    echo "Usage: $0 [-S skip_install <true|false>] [-s <android_serial>] [-t <boot_timeout>] [-o <COLLECT|ANALYZE>] [-n <collect_no>]" 1>&2
+    echo "Usage: $0 [-S skip_install <true|false>] [-t <boot_timeout>] [-o <COLLECT|ANALYZE>] [-n <collect_no>]" 1>&2
     exit 1
 }
 
-while getopts ":S:s:t:o:n:v:" o; do
+while getopts ":S:t:o:n:v:" o; do
   case "$o" in
     S) SKIP_INSTALL="${OPTARG}" ;;
-    s) ANDROID_SERIAL="${OPTARG}" ;;
     t) BOOT_TIMEOUT="${OPTARG}" ;;
     o) OPERATION="${OPTARG}" ;;
     n) COLLECT_NO="${OPTARG}" ;;

--- a/automated/android/boottime/boottime.yaml
+++ b/automated/android/boottime/boottime.yaml
@@ -3,9 +3,12 @@ metadata:
     format: "Lava-Test Test Definition 1.0"
     description: "collect the boottime data many times and try to analyse,
                   when run more than 4 times(including), the average will be
-                  calculated without the maximum and the minmun, if run less
-                  than or equal to 3 time, the average will be calculated with
-                  all data"
+                  calculated without the maximum and the minimum, if run less
+                  than or equal to 3 times, the average will be calculated with
+                  all data.
+                  If there are multiple android devices connected to
+                  the host, please export the android serial number via the
+                  ANDROID_SERIAL environment variable before running the scripts"
     maintainer:
         - yongqin.liu@linaro.org
         - chase.qi@linaro.org
@@ -22,8 +25,6 @@ params:
     ANDROID_VERSION: ""
     # specify true or false to skip or not the installation of lxc packages
     SKIP_INSTALL: "false"
-    # Specify device serial no. when more than one device connected.
-    ANDROID_SERIAL: ""
     # Specify timeout in seconds for wait_boot_completed.
     BOOT_TIMEOUT: "300"
     # Available operations: COLLECT or ANALYZE
@@ -36,7 +37,7 @@ params:
 run:
     steps:
         - cd ./automated/android/boottime
-        - ./boottime.sh -S "${SKIP_INSTALL}" -s "${ANDROID_SERIAL}" -t "${BOOT_TIMEOUT}" -o "${OPERATION}" -n "${COLLECT_NO}" -v "${ANDROID_VERSION}"
+        - ./boottime.sh -S "${SKIP_INSTALL}" -t "${BOOT_TIMEOUT}" -o "${OPERATION}" -n "${COLLECT_NO}" -v "${ANDROID_VERSION}"
         - if [ "${OPERATION}" = "ANALYZE" ]; then ../../utils/upload-to-artifactorial.sh -a "output/boottime.tgz" -u "${URL}" -t "${TOKEN}"; fi
         - ../../utils/send-to-lava.sh ./output/boot_result.txt
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -82,3 +82,7 @@ adb_join_wifi "${AP_SSID}" "${AP_KEY}"
 # Run tradefed test.
 info_msg "About to run tradefed shell on device ${ANDROID_SERIAL}"
 ./tradefed-runner.py -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULT_FORMAT}" -f "${FAILURES_PRINTED}"
+# When adb device lost, end test job to mark it as 'incomplete'.
+if ! adb shell echo ok; then
+    error_fatal "tradefed: adb device lost[$ANDROID_SERIAL]"
+fi

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -65,7 +65,5 @@ run:
         # Send test result to LAVA.
         - ../../utils/send-to-lava.sh ./output/result.txt
         - userdel testuser -f -r || true
-        # When adb device lost, end test job to mark it as 'incomplete'.
-        - if ! adb shell echo ok; then error_fatal "tradefed: adb device lost[$ANDROID_SERIAL]"; fi
         - if echo "${TEST_REBOOT_EXPECTED}" |grep -i "true" ; then killall monitor_fastboot.sh; fi
         - killall monitor_adb.sh


### PR DESCRIPTION
to workaround the naming conflict with the docker method.
with the docker method, ANDROID_SERIAL defined in the yaml file
or in the boottime.sh will cause the adb get-serialno failed to
get the device serial number.

If there is a need to specify the serial number for the script here,
plese export ANDROID_SERIAL explicitly before running the scripts.

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>