### PR TITLE
LTP: Skip long running test cases bind06 cve-2018-18559

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -308,3 +308,15 @@ skiplist:
       - all
     tests:
       - memcg_stress
+
+  - reason: >
+      skip long running LTP bind06 and cve-2018-18559 on all devices
+    url: https://bugs.linaro.org/show_bug.cgi?id=5721
+    environments: production
+    boards:
+      - all
+    branches:
+      - all
+    tests:
+      - bind06
+      - cve-2018-18559


### PR DESCRIPTION
all other LTP test runs for 15 minutes at max but this test case
is running for 30 minutes which is too long. So skipping till it
get fixed upstream.

ref:
https://bugs.linaro.org/show_bug.cgi?id=5721

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>