### PR TITLE
LTP: Adding ftrace_stress_test.sh as known issues

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -320,3 +320,14 @@ skiplist:
     tests:
       - bind06
       - cve-2018-18559
+
+  - reason: >
+      LTP tracing test case ftrace_stress_test.sh crashing on all devices.
+    url: https://bugs.linaro.org/show_bug.cgi?id=5722
+    environments: production
+    boards:
+      - all
+    branches:
+      - all
+    tests:
+      - ftrace_stress_test.sh


### PR DESCRIPTION
LTP tracing test case ftrace_stress_test.sh crashing on all devices.
ftrace_buffer_size_kb.sh: line 33: echo: write error: Cannot allocate memory
rcu: INFO: rcu_sched detected stalls on CPUs/tasks
RIP: 0010:queued_spin_lock_slowpath+0x46/0x1b0

ref:
https://bugs.linaro.org/show_bug.cgi?id=5722

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>