### PR TITLE
sanity-check: disable verbose output

### DIFF
--- a/sanity-check.sh
+++ b/sanity-check.sh
@@ -4,8 +4,7 @@ set -ex
 python3 validate.py \
     -r build-error.txt \
     -p E501 W503 \
-    -s SC1091 SC2230 \
-    -v
+    -s SC1091 SC2230
 
 # pycodestyle checks skipped:
 # E510: line too long


### PR DESCRIPTION
The repository is in a state where all files pass sanity check. This
means that the only interesting fact is when something breaks. This
change allows to only display failed test results instead of all.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>