### PR TITLE
noninteractive-tradefed: collect more information to debug fastboot c…

### DIFF
--- a/automated/android/noninteractive-tradefed/debug-fastboot.sh
+++ b/automated/android/noninteractive-tradefed/debug-fastboot.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# check the user that run this script
+id
+echo "----fastboot devices list from /sys/bus/usb/devices start----"
+fastboot_devices=""
+devpaths=""
+#ls /sys/bus/usb/drivers/usb/*/serial | while read -r device; do
+#ls /sys/bus/usb/devices/*/serial | while read -r device; do
+find -L /sys/bus/usb/devices/ -maxdepth 2 -type f -name serial | while read -r device; do
+    basedir=$(dirname "${device}")
+    realpath_basedir=$(realpath "${basedir}")
+    basedir_name=$(basename "${basedir}")
+    #interface_dir="/sys/bus/usb/devices/${basedir_name}/${basedir_name}:1.*"
+    #ls -1d /sys/bus/usb/devices/${basedir_name}/${basedir_name}:1.* 2>/dev/null| while read -r interface; do
+    find -L "/sys/bus/usb/devices/${basedir_name}" -maxdepth 1 -mindepth 1  -type d -name "${basedir_name}:1.*" | while read -r interface; do
+        bInterfaceClass=$(cat "${interface}/bInterfaceClass")
+        bInterfaceSubClass=$(cat "${interface}/bInterfaceSubClass")
+        bInterfaceProtocol=$(cat "${interface}/bInterfaceProtocol")
+        if [ "X${bInterfaceClass}" = "Xff" ] && \
+                [ "X${bInterfaceSubClass}" = "X42" ] && \
+                [ "X${bInterfaceProtocol}" = "X03" ]; then
+
+            devnum=$(cat "${interface}/devnum")
+            busnum=$(cat "${interface}/busnum")
+            serial=$(cat "${device}")
+            if [ ! -f "${interface}/interface" ]; then
+                echo "${serial} no-interface-fastboot ${device}"
+
+                fastboot_devices="${fastboot_devices} ${realpath_basedir}"
+
+                busnum=$(printf "%03d" "${busnum}")
+                devnum=$(printf "%03d" "${devnum}")
+                devpath="/dev/bus/usb/${busnum}/${devnum}"
+                devpaths="${devpaths} ${devpath}"
+            else
+                echo "${serial} interface-$(cat "${interface}/interface") ${device}"
+            fi
+        fi
+    done
+done
+echo "----fastboot devices list from /sys/bus/usb/devices end----"
+echo "----fastboot devices list from fastboot devices command start----"
+fastboot devices
+echo "----fastboot devices list from fastboot devices command end----"
+# check the owner and group of the android devices
+echo "----list usb devices owner and group start----"
+ls -l /dev/bus/usb/*/*
+echo "----list usb devices owner and group end----"

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -59,6 +59,7 @@ run:
         - cp -r ./${TEST_PATH}/logs ./output/ || true
         # Include logs dumped from TF shell 'd l' command.
         - if ls /tmp/tradefed*; then cp -r /tmp/tradefed* ./output || true; fi
+        - dmesg > ./output/dmesg-host.txt
         - tar caf tradefed-output-$(date +%Y%m%d%H%M%S).tar.xz ./output
         - ATTACHMENT=$(ls tradefed-output-*.tar.xz)
         - ../../utils/upload-to-artifactorial.sh -a "${ATTACHMENT}" -u "${URL}" -t "${TOKEN}"
@@ -66,6 +67,6 @@ run:
         - ../../utils/send-to-lava.sh ./output/result.txt
         - userdel testuser -f -r || true
         # When adb device lost, end test job to mark it as 'incomplete'.
-        - if ! adb shell echo ok; then error_fatal "tradefed - adb device lost[$ANDROID_SERIAL]"; fi
+        - if ! adb shell echo ok; then ./debug-fastboot.sh; error_fatal "tradefed - adb device lost[$ANDROID_SERIAL]"; fi
         - if echo "${TEST_REBOOT_EXPECTED}" |grep -i "true" ; then killall monitor_fastboot.sh; fi
         - killall monitor_adb.sh


### PR DESCRIPTION
…onnection

including the host side dmesg log, and the fastboot devies information
from /sys and /dev/bus/usb/

with hikey jobs, the hikey board was changed to the recovery mode instead of the fastboot mode after the reboot during the test, and this change is used to collect the information.

after rooted, the hikey board was changed to recovery mode now
    [823643.829055] usb 2-1.1.1.4: new full-speed USB device number 106 using ehci-pci
    [823643.938547] usb 2-1.1.1.4: New USB device found, idVendor=12d1, idProduct=3609, bcdDevice= 0.00
    [823643.938550] usb 2-1.1.1.4: New USB device strings: Mfr=1, Product=4, SerialNumber=0
    [823643.938552] usb 2-1.1.1.4: Product: \xe3\x84\xb0㌲㔴㜶㤸
    [823643.938554] usb 2-1.1.1.4: Manufacturer: 䕇䕎䥎
    [823643.938977] option 2-1.1.1.4:1.0: GSM modem (1-port) converter detected
    [823643.939103] usb 2-1.1.1.4: GSM modem (1-port) converter now attached to ttyUSB25
    [823704.024606] usb 2-1.1.1.4: USB disconnect, device number 106
    [823704.024880] option1 ttyUSB25: GSM modem (1-port) converter now disconnected from ttyUSB25
    [823704.024904] option 2-1.1.1.4:1.0: device disconnected

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>