### PR TITLE
selftests: skip kvm kvm_create_max_vcpus on arm64

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -359,3 +359,29 @@ skiplist:
       - all
     tests:
       - vm/run_vmtests
+  - reason: >
+      kvm: kvm_create_max_vcpus hang on arm64 devices for stable rc 5.4 and below
+    url: https://bugs.linaro.org/show_bug.cgi?id=5729
+    environments: all
+    boards:
+      - dragonboard-410c
+      - hi6220-hikey
+      - juno-r2
+    branches:
+      - 5.4
+      - 4.19
+      - 4.14
+      - 4.9
+      - 4.4
+      - linux-5.4.y
+      - linux-4.19.y
+      - linux-4.14.y
+      - linux-4.9.y
+      - linux-4.4.y
+      - v5.4-rt
+      - v4.19-rt
+      - v4.14-rt
+      - v4.9-rt
+      - v4.4-rt
+    tests:
+      - kvm/kvm_create_max_vcpus


### PR DESCRIPTION
Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>