### PR TITLE
noninteractive-tradefed: add support for docker method

### DIFF
--- a/automated/android/noninteractive-tradefed/monitor_fastboot.sh
+++ b/automated/android/noninteractive-tradefed/monitor_fastboot.sh
@@ -2,6 +2,20 @@
 while true;
 do
     date
-    fastboot boot /lava-lxc/*boot*.img
+    # fastboot continue # still not supported for all platforms, like db845c, x15
+    # so continue using fastboot boot command here
+    echo "Run fastboot boot to wait and reboot the device again"
+    f_lxc_boot=$(find /lava-lxc -type f -name "*boot*.img")
+    f_docker_boot=$(find /lava-downloads -type f -name "*boot*.img")
+    if [ -n "${f_lxc_boot}" ] && [ -f "${f_lxc_boot}" ]; then
+        # for lxc container method
+        fastboot boot "${f_lxc_boot}"
+    elif [ -n "${f_docker_boot}" ] && [ -f "${f_docker_boot}" ]; then
+        # for docker method
+        fastboot boot "${f_docker_boot}"
+    else
+        echo "No boot image found under /lava-lxc and /lava-downloads, please check and try again!"
+        exit 1
+    fi
     sleep 30
 done

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -59,7 +59,7 @@ run:
         - cp -r ./${TEST_PATH}/logs ./output/ || true
         # Include logs dumped from TF shell 'd l' command.
         - if ls /tmp/tradefed*; then cp -r /tmp/tradefed* ./output || true; fi
-        - dmesg > ./output/dmesg-host.txt
+        - sudo dmesg > ./output/dmesg-host.txt || true
         - tar caf tradefed-output-$(date +%Y%m%d%H%M%S).tar.xz ./output
         - ATTACHMENT=$(ls tradefed-output-*.tar.xz)
         - ../../utils/upload-to-artifactorial.sh -a "${ATTACHMENT}" -u "${URL}" -t "${TOKEN}"


### PR DESCRIPTION
Including the two change for where the boot image is saved inside the docker and workaround for the dmesg permission problem