### PR TITLE
noninteractive-tradefed: add support for connecting to wifi with the …

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -76,8 +76,16 @@ if [ -e "${TEST_PATH}/testcases/vts/testcases/kernel/linux_kselftest/kselftest_c
     sed -i "/suspend/d" "${TEST_PATH}"/testcases/vts/testcases/kernel/linux_kselftest/kselftest_config.py
 fi
 
-# try to connect wifi if AP information specified
-adb_join_wifi "${AP_SSID}" "${AP_KEY}"
+if [ -n "${AP_SSID}" ] && [ -n "${AP_KEY}" ]; then
+    # try to connect to wifi with the feature provided by tradefed by default
+    # when AP_SSID and AP_KEY are specified for this tradefed test action explicitly
+    TEST_PARAMS="${TEST_PARAMS} --wifi-ssid ${AP_SSID} --wifi-psk ${AP_KEY}"
+else
+    # try to connect to wifi with the external AdbJoinWifi apk from
+    # https://github.com/steinwurf/adb-join-wifi
+    # if AP_SSID and AP_KEY are not specified for this tradefed test action
+    adb_join_wifi "${AP_SSID}" "${AP_KEY}"
+fi
 
 # Run tradefed test.
 info_msg "About to run tradefed shell on device ${ANDROID_SERIAL}"


### PR DESCRIPTION
…tradefed feature

not remove the call of AdbJoinWifi apk as it provides us another option
to check the wifi connection stablitiby.
and it supports to find the AP_SSID and AP_KEY from the secrets file,
which is not supported by this change yet.

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>