### PR TITLE
Remove "-q" option from pi_stress

### DIFF
--- a/automated/linux/pi-stress/pi-stress.sh
+++ b/automated/linux/pi-stress/pi-stress.sh
@@ -56,7 +56,7 @@ background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 # pi_stress will send SIGTERM when test fails. The single will terminate the
 # test script. Catch and ignore it with trap.
 trap '' TERM
-"${binary}" -q --duration "${DURATION}" "${MLOCKALL}" "${RR}" | tee "${LOGFILE}"
+"${binary}" --duration "${DURATION}" "${MLOCKALL}" "${RR}" | tee "${LOGFILE}"
 
 background_process_stop bgcmd
 


### PR DESCRIPTION
"-q" option will suppress "Current Inversions" to be displayed or redirected to a log file. 
Hence the pi-stress test is getting failed due to the condition statement where "Current Inversions" is being grep from log file.

**with "-q" option:**
----------------------------------------------------
$ pi_stress -q --duration 5s
Total inversion performed: 103858
Test Duration: 0 days, 0 hours, 0 minutes, 6 seconds

**without "-q" option:**
----------------------------------------------------
$ pi_stress --duration 5s
Starting PI Stress Test
Number of thread groups: 1
Duration of test run: 5 seconds
Number of inversions per group: unlimited
     Admin thread SCHED_FIFO priority 4
1 groups of 3 threads will be created
      High thread SCHED_FIFO priority 3
       Med thread SCHED_FIFO priority 2
       Low thread SCHED_FIFO priority 1
**Current Inversions**: 104116
Stopping test
Total inversion performed: 104117
Test Duration: 0 days, 0 hours, 0 minutes, 6 seconds