### PR TITLE
workload-automation3: Fix test_case names

### DIFF
--- a/automated/android/workload-automation3/aep-energy-config.sh
+++ b/automated/android/workload-automation3/aep-energy-config.sh
@@ -41,4 +41,4 @@ git clone "${AEP_CONFIG_REPOSITORY}" energy-probe-ext
 cd energy-probe-ext
 git checkout "${AEP_CONFIG_REF}"
 cp -r ./* "${AEP_CONFIG_TARGET_PATH}"
-report_pass "AEP config installed"
+report_pass "AEP_config_installed"

--- a/automated/android/workload-automation3/aep-install.sh
+++ b/automated/android/workload-automation3/aep-install.sh
@@ -41,4 +41,4 @@ git checkout "${AEP_REF}"
 ./configure --prefix=/usr
 make
 make install
-report_pass "AEP installed"
+report_pass "AEP_installed"


### PR DESCRIPTION
The send-to-lava.sh script expects a single word as a test case name
followed by the result. If the test case name contains multiple words
the script assumes that the second word is the test result. Let's fix
the test cases to be in the expected format to prevent errors like
this:

> echo  AEP config installed pass
> ...
> ../../utils/send-to-lava.sh ./output/result.txt
> <LAVA_SIGNAL_TESTCASE TEST_CASE_ID=AEP RESULT=config>
> Received signal: <TESTCASE> TEST_CASE_ID=AEP RESULT=config
> Bad test result: config

Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>