### PR TITLE
linux: perf: perf test results parser update

### DIFF
--- a/automated/linux/perf/perf.sh
+++ b/automated/linux/perf/perf.sh
@@ -90,8 +90,11 @@ run_perf_test() {
 parse_perf_test_results() {
     grep -a -E "Ok" "${RESULT_LOG}" | tee -a "${TEST_PASS_LOG}"
     sed -i -e 's/(//g' "${TEST_PASS_LOG}"
-    sed -i -e 's/)://g' "${TEST_PASS_LOG}"
+    sed -i -e 's/)//g' "${TEST_PASS_LOG}"
     sed -i -e 's/://g' "${TEST_PASS_LOG}"
+    sed -i -e "s/'//g" "${TEST_PASS_LOG}"
+    sed -i -e 's/&//g' "${TEST_PASS_LOG}"
+    sed -i -e 's/\*//g' "${TEST_PASS_LOG}"
     awk '{for (i=1; i<NF-1; i++) printf $i "-"; print $i " " $NF}' "${TEST_PASS_LOG}" 2>&1 | tee -a "${RESULT_FILE}"
     sed -i -e 's/Ok/pass/g' "${RESULT_FILE}"
 
@@ -100,6 +103,9 @@ parse_perf_test_results() {
     sed -i -e 's/(//g' "${TEST_FAIL_LOG}"
     sed -i -e 's/)//g' "${TEST_FAIL_LOG}"
     sed -i -e 's/://g' "${TEST_FAIL_LOG}"
+    sed -i -e "s/'//g" "${TEST_FAIL_LOG}"
+    sed -i -e 's/&//g' "${TEST_FAIL_LOG}"
+    sed -i -e 's/\*//g' "${TEST_FAIL_LOG}"
     awk '{for (i=1; i<NF-1; i++) printf $i "-"; print $i " " $NF }' "${TEST_FAIL_LOG}" 2>&1 | tee -a "${RESULT_FILE}"
     sed -i -e 's/FAILED\!/fail/g' "${RESULT_FILE}"
 
@@ -108,6 +114,9 @@ parse_perf_test_results() {
     sed -i -e 's/(//g' "${TEST_SKIP_LOG}"
     sed -i -e 's/)//g' "${TEST_SKIP_LOG}"
     sed -i -e 's/://g' "${TEST_SKIP_LOG}"
+    sed -i -e "s/'//g" "${TEST_SKIP_LOG}"
+    sed -i -e 's/&//g' "${TEST_SKIP_LOG}"
+    sed -i -e 's/\*//g' "${TEST_SKIP_LOG}"
     awk '{for (i=1; i<NF-1; i++) printf $i "-"; print $i " " $NF}' "${TEST_SKIP_LOG}" 2>&1 | tee -a "${RESULT_FILE}"
     sed -i -e 's/Skip/skip/g' "${RESULT_FILE}"
 


### PR DESCRIPTION
perf test results parser updated to remove some special characters in
test case names for easy results parsing by LAVA.

ref:
perf test: Output sub testing result in cs-etm
https://lore.kernel.org/lkml/20210215115944.535986-1-leo.yan@linaro.org/

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>