### PR TITLE
CI: Run black with --check

### DIFF
--- a/.github/workflows/test-plans-pipeline.yml
+++ b/.github/workflows/test-plans-pipeline.yml
@@ -21,10 +21,7 @@ jobs:
          python -m pip install --upgrade pip
          pip install pyyaml pycodestyle python-magic black
 
-      - name: Black check
-        run: |
-         black --check .
-
       - name: Linting
         run: |
+         black --check .
          ./sanity-check.sh

--- a/.github/workflows/test-plans-pipeline.yml
+++ b/.github/workflows/test-plans-pipeline.yml
@@ -21,7 +21,10 @@ jobs:
          python -m pip install --upgrade pip
          pip install pyyaml pycodestyle python-magic black
 
+      - name: Black check
+        run: |
+         black --check .
+
       - name: Linting
         run: |
-         black .
          ./sanity-check.sh

--- a/automated/android/multinode/tradefed/utils.py
+++ b/automated/android/multinode/tradefed/utils.py
@@ -28,7 +28,8 @@ class Device:
         )
         self.logcat_output_file = open(logcat_output_filename, "w")
         self.logcat = subprocess.Popen(
-            ["adb", "-s", serial_or_address, "logcat"], stdout=self.logcat_output_file,
+            ["adb", "-s", serial_or_address, "logcat"],
+            stdout=self.logcat_output_file,
         )
         self.worker_job_id = worker_job_id
         self.worker_handshake_iteration = 1
@@ -193,7 +194,13 @@ class Device:
         else:
             try:
                 subprocess.run(
-                    ["adb", "-s", self.serial_or_address, "reboot", "bootloader",],
+                    [
+                        "adb",
+                        "-s",
+                        self.serial_or_address,
+                        "reboot",
+                        "bootloader",
+                    ],
                     timeout=commandTimeoutSecs,
                 )
             except subprocess.TimeoutExpired:
@@ -252,7 +259,10 @@ class Device:
                 [
                     "lava-wait",
                     "worker-sync-%s-%s"
-                    % (self.worker_job_id, str(self.worker_handshake_iteration),),
+                    % (
+                        self.worker_job_id,
+                        str(self.worker_handshake_iteration),
+                    ),
                 ]
             )
             # TODO could check result variable from MultiNode cache

--- a/automated/android/tradefed/result_parser.py
+++ b/automated/android/tradefed/result_parser.py
@@ -113,7 +113,11 @@ class TradefedResultParser:
         failed_result = "pass"
         if tests_failed > 0:
             failed_result = "fail"
-        result = "%s_failed %s %s" % (module_name, failed_result, str(tests_failed),)
+        result = "%s_failed %s %s" % (
+            module_name,
+            failed_result,
+            str(tests_failed),
+        )
         py_test_lib.add_result(self.result_output_file, result)
 
         # output result to show if the module is done or not
@@ -147,7 +151,10 @@ class TradefedResultParser:
                 failures = failed_test.findall(".//Failure")
                 failure_msg = ""
                 for failure in failures:
-                    failure_msg = "%s \n %s" % (failure_msg, failure.get("message"),)
+                    failure_msg = "%s \n %s" % (
+                        failure_msg,
+                        failure.get("message"),
+                    )
 
                 self.logger.info("%s %s" % (test_name, failure_msg.strip()))
                 num_printed_failures += 1

--- a/automated/lib/android_ui_wifi.py
+++ b/automated/lib/android_ui_wifi.py
@@ -9,14 +9,14 @@ from uiautomator import Device
 def set_wifi_state(dut, turn_on):
     """Turn WiFi on or off.
 
-        This checks the current WiFi settings and turns it on or off. It does
-        nothing if the settings are already in the desired state.
+    This checks the current WiFi settings and turns it on or off. It does
+    nothing if the settings are already in the desired state.
 
-        Parameters:
-            dut (Device): The device object.
-            enabled: Boolean, true for on, false for off
-        Raises:
-            DeviceCommandError: If the UI automation fails.
+    Parameters:
+        dut (Device): The device object.
+        enabled: Boolean, true for on, false for off
+    Raises:
+        DeviceCommandError: If the UI automation fails.
     """
     # Open the Wi-Fi settings
     adb(
@@ -76,7 +76,10 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.ACTION[0] != "set_wifi_state" or args.ACTION[1] not in ("on", "off",):
+    if args.ACTION[0] != "set_wifi_state" or args.ACTION[1] not in (
+        "on",
+        "off",
+    ):
         print(
             "ERROR: Specified ACTION is not supported: {}".format(args.ACTION),
             file=sys.stderr,

--- a/automated/utils/test-runner.py
+++ b/automated/utils/test-runner.py
@@ -615,25 +615,25 @@ class ManualTestRun(TestRun, cmd.Cmd):
 
 
 def get_packages(linux_distribution, target=None):
-    """ Return a list of installed packages with versions
+    """Return a list of installed packages with versions
 
-        linux_distribution is a string that may be 'debian',
-            'ubuntu', 'centos', or 'fedora'.
+    linux_distribution is a string that may be 'debian',
+        'ubuntu', 'centos', or 'fedora'.
 
-        For example (ubuntu):
-        'packages': ['acl-2.2.52-2',
-                     'adduser-3.113+nmu3',
-                     ...
-                     'zlib1g:amd64-1:1.2.8.dfsg-2+b1',
-                     'zlib1g-dev:amd64-1:1.2.8.dfsg-2+b1']
+    For example (ubuntu):
+    'packages': ['acl-2.2.52-2',
+                 'adduser-3.113+nmu3',
+                 ...
+                 'zlib1g:amd64-1:1.2.8.dfsg-2+b1',
+                 'zlib1g-dev:amd64-1:1.2.8.dfsg-2+b1']
 
-        (centos):
-        "packages": ["acl-2.2.51-12.el7",
-                     "apr-1.4.8-3.el7",
-                     ...
-                     "zlib-1.2.7-17.el7",
-                     "zlib-devel-1.2.7-17.el7"
-        ]
+    (centos):
+    "packages": ["acl-2.2.51-12.el7",
+                 "apr-1.4.8-3.el7",
+                 ...
+                 "zlib-1.2.7-17.el7",
+                 "zlib-devel-1.2.7-17.el7"
+    ]
     """
 
     logger = logging.getLogger("RUNNER.get_packages")
@@ -661,27 +661,27 @@ def get_packages(linux_distribution, target=None):
 
 
 def get_environment(target=None, skip_collection=False):
-    """ Return a dictionary with environmental information
+    """Return a dictionary with environmental information
 
-        target: optional ssh host string to gather environment remotely.
-        skip_collection: Skip data collection and return an empty dictionary.
+    target: optional ssh host string to gather environment remotely.
+    skip_collection: Skip data collection and return an empty dictionary.
 
-        For example (on a HiSilicon D03):
-        {
-            "bios_version": "Hisilicon D03 UEFI 16.12 Release",
-            "board_name": "D03",
-            "board_vendor": "Huawei",
-            "kernel": "4.9.0-20.gitedc2a1c.linaro.aarch64",
-            "linux_distribution": "centos",
-            "packages": [
-                "GeoIP-1.5.0-11.el7",
-                "NetworkManager-1.4.0-20.el7_3",
-                ...
-                "yum-plugin-fastestmirror-1.1.31-40.el7",
-                "zlib-1.2.7-17.el7"
-            ],
-            "uname": "Linux localhost.localdomain 4.9.0-20.gitedc2a1c.linaro.aarch64 #1 SMP Wed Dec 14 17:50:15 UTC 2016 aarch64 aarch64 aarch64 GNU/Linux"
-        }
+    For example (on a HiSilicon D03):
+    {
+        "bios_version": "Hisilicon D03 UEFI 16.12 Release",
+        "board_name": "D03",
+        "board_vendor": "Huawei",
+        "kernel": "4.9.0-20.gitedc2a1c.linaro.aarch64",
+        "linux_distribution": "centos",
+        "packages": [
+            "GeoIP-1.5.0-11.el7",
+            "NetworkManager-1.4.0-20.el7_3",
+            ...
+            "yum-plugin-fastestmirror-1.1.31-40.el7",
+            "zlib-1.2.7-17.el7"
+        ],
+        "uname": "Linux localhost.localdomain 4.9.0-20.gitedc2a1c.linaro.aarch64 #1 SMP Wed Dec 14 17:50:15 UTC 2016 aarch64 aarch64 aarch64 GNU/Linux"
+    }
     """
 
     environment = {}


### PR DESCRIPTION
Black should run with --check, so it exits with exit code 1, not 0 plus
doesn't reformat, but fails the build.

Signed-off-by: Benjamin Copeland <ben.copeland@linaro.org>