### PR TITLE
README: Use GitHub actions workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Build status
-[![Build Status](https://travis-ci.com/Linaro/test-definitions.svg?branch=master)](https://travis-ci.com/Linaro/test-definitions)
+![Build Status](https://github.com/Linaro/test-definitions/actions/workflows/test-plans-pipeline.yml/badge.svg)
+![REUSE Compliance Check](https://github.com/Linaro/test-definitions/actions/workflows/reuse.yml/badge.svg)
 
 # Test Definitions
 A set of testing scripts designed to work with [LAVA](http://lavasoftware.org/).


### PR DESCRIPTION
Updating our README to use GitHub workflow status, instead of TravisCI
as this is no longer used.

Signed-off-by: Benjamin Copeland <ben.copeland@linaro.org>