### PR TITLE
linux: Adding packetdrill test suite

### DIFF
--- a/automated/linux/packetdrill/packetdrill.sh
+++ b/automated/linux/packetdrill/packetdrill.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+
+RESULT_LOG="${OUTPUT}/result_log.txt"
+TMP_LOG="${OUTPUT}/tmp_log.txt"
+
+TEST_PROGRAM=packetdrill
+TEST_PROG_VERSION=
+TEST_GIT_URL=https://github.com/google/packetdrill.git
+TEST_DIR="/opt/${TEST_PROGRAM}"
+SKIP_INSTALL="false"
+
+usage() {
+    echo "\
+    Usage: [sudo] ./packetdrill.sh [-d <DURATION>] [-v <TEST_PROG_VERSION>]
+                  [-u <TEST_GIT_URL>] [-p <TEST_DIR>] [-s <true|false>]
+
+    <TEST_PROG_VERSION>:
+    If this parameter is set, then the ${TEST_PROGRAM} is cloned. In
+    particular, the version of the suite is set to the commit
+    pointed to by the parameter. A simple choice for the value of
+    the parameter is, e.g., HEAD. If, instead, the parameter is
+    not set, then the suite present in TEST_DIR is used.
+
+    <TEST_GIT_URL>:
+    If this parameter is set, then the ${TEST_PROGRAM} is cloned
+    from the URL in TEST_GIT_URL. Otherwise it is cloned from the
+    standard repository for the suite. Note that cloning is done
+    only if TEST_PROG_VERSION is not empty
+
+    <TEST_DIR>:
+    If this parameter is set, then the ${TEST_PROGRAM} suite is cloned to or
+    looked for in TEST_DIR. Otherwise it is cloned to /opt/${TEST_PROGRAM}
+
+    <SKIP_INSTALL>:
+    If you already have it installed into the rootfs.
+    default: false"
+}
+
+while getopts "h:p:u:s:v:" opt; do
+    case $opt in
+        u)
+            if [[ "$OPTARG" != '' ]]; then
+                TEST_GIT_URL="${OPTARG}"
+            fi
+            ;;
+        p)
+            if [[ "$OPTARG" != '' ]]; then
+                TEST_DIR="${OPTARG}"
+            fi
+            ;;
+        s)
+            SKIP_INSTALL="${OPTARG}"
+            ;;
+        v)
+            TEST_PROG_VERSION="${OPTARG}"
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+install() {
+    dist=
+    dist_name
+    case "${dist}" in
+        debian|ubuntu)
+          [[ -n "${TEST_GIT_URL}" ]] && pkgs="git"
+          pkgs="${pkgs} build-essential automake curl bison flex ethtool net-tools iproute2 python python3"
+          install_deps "${pkgs}" "${SKIP_INSTALL}"
+          ;;
+        fedora|centos)
+          [[ -n "${TEST_GIT_URL}" ]] && pkgs="git-core"
+          pkgs=" ${pkgs} gcc gcc-c++ kernel-devel make automake curl bison flex ethtool net-tools iproute2 python python3"
+          install_deps "${pkgs}" "${SKIP_INSTALL}"
+          ;;
+        # When build do not have package manager
+        # Assume dependencies pre-installed
+        *)
+          echo "Unsupported distro: ${dist}! Package installation skipped!"
+          ;;
+    esac
+}
+
+parse_output() {
+    # Avoid results summary lines having special characters
+    sed -i -e 's/\// /g' "${RESULT_LOG}"
+    sed -i -e 's/(//g' -e 's/)//g' "${RESULT_LOG}"
+    sed -i -e 's/\[//g' -e 's/]//g' "${RESULT_LOG}"
+
+    # Parse each type of results
+    grep -E "OK" "${RESULT_LOG}"  2>&1 | tee "${TMP_LOG}"
+    awk '{for (i=NF-3; i<NF; i++) printf $i "-"; print $i " " "pass"}' "${TMP_LOG}" 2>&1 | tee "${RESULT_FILE}"
+
+    grep -E "FAIL" "${RESULT_LOG}" 2>&1 | tee "${TMP_LOG}"
+    awk '{for (i=NF-3; i<NF; i++) printf $i "-"; print $i " " "fail"}' "${TMP_LOG}" 2>&1 | tee -a "${RESULT_FILE}"
+
+    grep -E "SKIP" "${RESULT_LOG}" 2>&1 | tee "${TMP_LOG}"
+    awk '{for (i=NF-3; i<NF; i++) printf $i "-"; print $i " " "skip"}' "${TMP_LOG}" 2>&1 | tee -a "${RESULT_FILE}"
+
+    # Clean up
+    rm -rf "${TMP_LOG}" "${RESULT_LOG}"
+
+}
+
+build_install_tests() {
+    pushd "${TEST_DIR}/gtests/net/packetdrill" || exit 1
+    ./configure
+    make all
+    popd || exit 1
+}
+
+run_test() {
+    pushd "${TEST_DIR}/gtests/net" || exit 1
+    python3 ./packetdrill/run_all.py -v -l -L  2>&1 | tee -a "${RESULT_LOG}"
+    popd || exit 1
+}
+
+! check_root && error_msg "This script must be run as root"
+
+# Install and run test
+if [ "${SKIP_INSTALL}" = "true" ] || [ "${SKIP_INSTALL}" = "True" ]; then
+    info_msg "Skip installing package dependency for ${TEST_PROG_VERSION}"
+else
+    install
+fi
+
+get_test_program "${TEST_GIT_URL}" "${TEST_DIR}" "${TEST_PROG_VERSION}" "${TEST_PROGRAM}"
+build_install_tests
+create_out_dir "${OUTPUT}"
+run_test
+parse_output

--- a/automated/linux/packetdrill/packetdrill.yaml
+++ b/automated/linux/packetdrill/packetdrill.yaml
@@ -1,0 +1,62 @@
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: packetdrill
+    description: |
+                  The packetdrill scripting tool enables quick, precise tests for entire
+                  TCP/UDP/IPv4/IPv6 network stacks, from the system call layer down to the NIC
+                  hardware. packetdrill currently works on Linux, FreeBSD, OpenBSD, and NetBSD.
+                  It can test network stack behavior over physical NICs on a LAN, or on a single
+                  machine using a tun virtual network device.
+
+                  The code is GPLv2. Currently the source for the testing tool and a number of
+                  test scripts is in the git repository. We will continue to post more tests from
+                  our team's Linux TCP test suite (described in our USENIX paper), as time
+                  permits.
+
+
+    maintainer:
+        - anders.roxell@linaro.org
+        - naresh.kamboju@linaro.org
+    os:
+        - debian
+        - ubuntu
+        - fedora
+        - centos
+        - openembedded
+    scope:
+        - functional
+    devices:
+        - dragonboard410c
+        - hi6220-hikey
+        - juno
+        - nxp-ls2088
+        - x15
+        - x86
+
+params:
+        # If the following parameter is set, then the packetdrill suite is
+        # cloned and used unconditionally. In particular, the version
+        # of the suite is set to the commit pointed to by the
+        # parameter. A simple choice for the value of the parameter
+        # is, e.g., HEAD.  If, instead, the parameter is
+        # not set, then the suite present in TEST_DIRis used.
+        TEST_PROG_VERSION: ""
+
+        # If next parameter is set, then the packetdrill suite is cloned
+        # from the URL in TEST_GIT_URL. Otherwise it is cloned from the
+        # standard repository for the suite. Note that cloning is done
+        # only if TEST_PROG_VERSION is not empty
+        TEST_GIT_URL: ""
+
+        # If next parameter is set, then the packetdrill suite is cloned to or
+        # looked for in TEST_DIR. Otherwise it is cloned to $(pwd)/packetdrill
+        TEST_DIR: ""
+
+        # If the user space already have everything installed. default: false
+        SKIP_INSTALL: "false"
+
+run:
+    steps:
+        - cd ./automated/linux/packetdrill/
+        - ./packetdrill.sh -v "${TEST_PROG_VERSION}" -s "${SKIP_INSTALL}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}"
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Adding packetdrill test suite to Linaro test definitions.

The packetdrill scripting tool enables quick, precise tests for entire
TCP/UDP/IPv4/IPv6 network stacks, from the system call layer down to
the NIC hardware. packetdrill currently works on Linux, FreeBSD,
OpenBSD, and NetBSD. It can test network stack behavior over physical
NICs on a LAN, or on a single machine using a tun virtual network
device.

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>