### PR TITLE
crypto: add cryptsetup benchmark test

### DIFF
--- a/automated/linux/crypto/cryptsetup.sh
+++ b/automated/linux/crypto/cryptsetup.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+. ../../lib/sh-test-lib
+
+OUTPUT="$(pwd)/output"
+mkdir -p "${OUTPUT}"
+RESULT_FILE="${OUTPUT}/result.txt"
+export RESULT_FILE
+TEST_SUITE="cryptsetup"
+
+usage() {
+    echo "Usage: $0 [-s] [-h <hash>] [-c <cipher>]" 1>&2
+    exit 1
+}
+
+while getopts "h:c:s:" o; do
+    case "$o" in
+        h) HASH="${OPTARG}" ;;
+        c) CIPHER="${OPTARG}" ;;
+        s) SKIP_INSTALL="${OPTARG}" ;;
+        *) usage ;;
+    esac
+done
+
+echo HASH="${HASH}"
+echo CIPHER="${CIPHER}"
+
+create_out_dir "${OUTPUT}"
+
+install_deps "cryptsetup" "${SKIP_INSTALL}"
+
+# First test to check if cryptsetup is properly installed
+cryptsetup --version
+exit_on_fail "${TEST_SUITE}-version"
+
+for h in ${HASH}; do
+    LOG_FILE="${OUTPUT}/${TEST_SUITE}-hash-$h.txt"
+    if pipe0_status "cryptsetup benchmark -h $h" "tee ${LOG_FILE}"; then
+        # get metric
+        iter=$(grep -v "^#" "${LOG_FILE}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -s ' ' | cut -d' ' -f2)
+        add_metric "${TEST_SUITE}-benchmark-hash-$h" "pass" "$iter" "iter/s"
+    else
+        report_fail "${TEST_SUITE}-benchmark-hash-$h"
+    fi
+done
+
+for c in ${CIPHER}; do
+    cipher=$(echo "$c" | cut -d'_' -f1)
+    key=$(echo "$c" | cut -d'_' -f2)
+    LOG_FILE="${OUTPUT}/${TEST_SUITE}-cipher-$c.txt"
+    if pipe0_status "cryptsetup benchmark -c $cipher -s $key" "tee ${LOG_FILE}"; then
+        # get metric
+        result=$(grep -v "^#" "${LOG_FILE}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' | tr -s ' ')
+        enc=$(echo "$result" | cut -d' ' -f3)
+        enc_unit=$(echo "$result" | cut -d' ' -f4)
+        add_metric "${TEST_SUITE}-benchmark-cipher-$c-encryption" "pass" "$enc" "$enc_unit"
+        dec=$(echo "$result" | cut -d' ' -f5)
+        dec_unit=$(echo "$result" | cut -d' ' -f6)
+        add_metric "${TEST_SUITE}-benchmark-cipher-$c-decryption" "pass" "$dec" "$dec_unit"
+    else
+        report_fail "${TEST_SUITE}-benchmark-cipher-$c-encryption"
+        report_fail "${TEST_SUITE}-benchmark-cipher-$c-decryption"
+    fi
+done

--- a/automated/linux/crypto/cryptsetup.yaml
+++ b/automated/linux/crypto/cryptsetup.yaml
@@ -1,0 +1,28 @@
+metadata:
+    name: cryptsetup
+    format: "Lava-Test Test Definition 1.0"
+    description: "Cryptsetup benchmark tests"
+    maintainer:
+        - nicolas.dechesne@linaro.org
+    os:
+        - debian
+        - ubuntu
+        - centos
+        - fedora
+    scope:
+        - crypto
+    devices:
+        - all
+    environment:
+        - lava-test-shell
+
+params:
+    SKIP_INSTALL: "false"
+    HASH: "sha1 sha256 sha512"
+    CIPHER: "aes-cbc_128 aes-cbc_256 aes-xts_256 aes-xts_512"
+
+run:
+    steps:
+        - cd ./automated/linux/crypto/
+        - ./cryptsetup.sh -s "${SKIP_INSTALL}" -h "${HASH}" -c "${CIPHER}"
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Use the cryptsetup utility to run some basic benchmarks.

HASH and CIPHER params are used to indicate which algorithms to
benchmark.

For CIPHER, we concatenate the alg name with the key size, so that we
can test multiple sizes.

Here is a more complex value for CIPERH, which can be used in a test
plan:

CIPHER='aes-cbc_128 aes-cbc_256 aes-xts_256 aes-xts_512 \
        serpent-cbc_128 serpent-cbc_256 serpent-xts_256 serpent-xts_512 \
        twofish-cbc_128 twofish-cbc_256 twofish-xts_256 twofish-xts_512'

Here is a sample output, running on an x86 laptop:

<TEST_CASE_ID=cryptsetup-version RESULT=pass>
<TEST_CASE_ID=cryptsetup-benchmark-hash-sha1 RESULT=pass>
<TEST_CASE_ID=cryptsetup-benchmark-sha1 RESULT=pass MEASUREMENT=1646116 UNITS=iter/s>
<TEST_CASE_ID=cryptsetup-benchmark-hash-sha256 RESULT=pass>
<TEST_CASE_ID=cryptsetup-benchmark-sha256 RESULT=pass MEASUREMENT=2072284 UNITS=iter/s>
<TEST_CASE_ID=cryptsetup-benchmark-hash-sha512 RESULT=pass>
<TEST_CASE_ID=cryptsetup-benchmark-sha512 RESULT=pass MEASUREMENT=1485235 UNITS=iter/s>
<TEST_CASE_ID=cryptsetup-benchmark-cipher-aes-cbc_128 RESULT=pass>
<TEST_CASE_ID=cryptsetup-benchmark-aes-cbc_128-encryption RESULT=pass MEASUREMENT=1076.7 UNITS=MiB/s>
<TEST_CASE_ID=cryptsetup-benchmark-aes-cbc_128-decryption RESULT=pass MEASUREMENT=3210.5 UNITS=MiB/s>
<TEST_CASE_ID=cryptsetup-benchmark-cipher-aes-cbc_256 RESULT=pass>
<TEST_CASE_ID=cryptsetup-benchmark-aes-cbc_256-encryption RESULT=pass MEASUREMENT=815.4 UNITS=MiB/s>
<TEST_CASE_ID=cryptsetup-benchmark-aes-cbc_256-decryption RESULT=pass MEASUREMENT=2626.8 UNITS=MiB/s>
<TEST_CASE_ID=cryptsetup-benchmark-cipher-aes-xts_256 RESULT=pass>
<TEST_CASE_ID=cryptsetup-benchmark-aes-xts_256-encryption RESULT=pass MEASUREMENT=3190.7 UNITS=MiB/s>
<TEST_CASE_ID=cryptsetup-benchmark-aes-xts_256-decryption RESULT=pass MEASUREMENT=3189.6 UNITS=MiB/s>
<TEST_CASE_ID=cryptsetup-benchmark-cipher-aes-xts_512 RESULT=pass>
<TEST_CASE_ID=cryptsetup-benchmark-aes-xts_512-encryption RESULT=pass MEASUREMENT=2596.5 UNITS=MiB/s>
<TEST_CASE_ID=cryptsetup-benchmark-aes-xts_512-decryption RESULT=pass MEASUREMENT=2566.6 UNITS=MiB/s>

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>