### PR TITLE
automated: linux: fwts: add a variable to skip tests

### DIFF
--- a/automated/linux/fwts/fwts.sh
+++ b/automated/linux/fwts/fwts.sh
@@ -14,6 +14,7 @@ TEST_SKIP_LOG="${OUTPUT}/test_skip_log.txt"
 export RESULT_FILE
 
 TESTS=""
+SKIP_TESTS=""
 TEST_PROGRAM=fwts
 TEST_PROG_VERSION=
 TEST_GIT_URL=https://github.com/ColinIanKing/fwts.git
@@ -34,6 +35,9 @@ usage() {
 	(such as having an X session running). Results are
 	indistinguishable w.r.t. to actually starting these applications.
 	Default value: \"throughput replayed-startup\"
+
+	<SKIP_TESTS>:
+	Skip listed tests, e.g. s3,nx,method
 
 	<TEST_PROG_VERSION>:
 	If this parameter is set, then the ${TEST_PROGRAM} suite is cloned. In
@@ -57,10 +61,13 @@ usage() {
 	default: false"
 }
 
-while getopts "h:t:p:u:v:s:" opt; do
+while getopts "h:t:k:p:u:v:s:" opt; do
 	case $opt in
 		t)
 			TESTS="$OPTARG"
+			;;
+		k)
+			SKIP_TESTS="--skip-test=$OPTARG"
 			;;
 		v)
 			TEST_PROG_VERSION="$OPTARG"
@@ -166,7 +173,7 @@ run_test() {
 	# In this case we don't want to add extra quote since that can make the
 	# string get splitted.
 	# shellcheck disable=SC2086
-	fwts ${TESTS} - 2>&1 | tee -a "${RESULT_LOG}"
+	fwts ${TESTS} ${SKIP_TESTS} - 2>&1 | tee -a "${RESULT_LOG}"
 	parse_fwts_test_results
 }
 

--- a/automated/linux/fwts/fwts.yaml
+++ b/automated/linux/fwts/fwts.yaml
@@ -24,6 +24,9 @@ params:
         # Set of tests.
         TESTS: ""
 
+        # Skip listed tests, e.g. s3,nx,method
+        SKIP_TESTS: ""
+
         # If the following parameter is set, then the FWTS suite is
         # cloned and used unconditionally. In particular, the version
         # of the suite is set to the commit pointed to by the
@@ -46,5 +49,5 @@ params:
 run:
     steps:
         - cd ./automated/linux/fwts/
-        - ./fwts.sh -t "${TESTS}" -v "${TEST_PROG_VERSION}" -s "${SKIP_INSTALL}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}"
+        - ./fwts.sh -t "${TESTS}" -k "${SKIP_TESTS}" -v "${TEST_PROG_VERSION}" -s "${SKIP_INSTALL}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Add a skip test variable if a few tests needs to be skipped.
Instead of having to list all 80 tests in the TESTS variable just list
the few tests you want to skip in variable SKIP_TESTS.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>