### PR TITLE
workload-automation3: Save the lava-target-ip to hosts

### DIFF
--- a/automated/linux/workload-automation3/workload-automation.sh
+++ b/automated/linux/workload-automation3/workload-automation.sh
@@ -95,6 +95,7 @@ sed -i 's/^# *PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 grep "PermitRootLogin yes" /etc/ssh/sshd_config
 echo "root:linaro123" | chpasswd
 /etc/init.d/ssh restart && sleep 3
+echo "$(lava-target-ip) lava-target-ip" >> /etc/hosts
 
 # Ensure that csv is enabled in result processors.
 if ! grep -q 'csv' ./config.yaml; then


### PR DESCRIPTION
Save the IPv4 address of the target to /etc/hosts to make it easier
for scripts to connect to the target by using just a fixed hostname.

Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>