### PR TITLE
automated: utils: test-runner: fix black formatting issues

### DIFF
--- a/automated/utils/test-runner.py
+++ b/automated/utils/test-runner.py
@@ -61,7 +61,7 @@ SSH_PARAMS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o Ser
 
 
 def run_command(command, target=None):
-    """ Run a shell command. If target is specified, ssh to the given target first. """
+    """Run a shell command. If target is specified, ssh to the given target first."""
 
     run = command
     if target:


### PR DESCRIPTION
With black-21.4b1-py3-none-any.whl the following black formatting issue shows up
with a diff like this:
-    """ Run a shell command. If target is specified, ssh to the given target first. """
+    """Run a shell command. If target is specified, ssh to the given target first."""

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>