### PR TITLE
monitor_fastboot.sh: support for the file name of boot.img

### DIFF
--- a/automated/android/noninteractive-tradefed/monitor_fastboot.sh
+++ b/automated/android/noninteractive-tradefed/monitor_fastboot.sh
@@ -5,8 +5,8 @@ do
     # fastboot continue # still not supported for all platforms, like db845c, x15
     # so continue using fastboot boot command here
     echo "Run fastboot boot to wait and reboot the device again"
-    f_lxc_boot=$(find /lava-lxc -type f -name "*-boot.img")
-    f_docker_boot=$(find /lava-downloads -type f -name "*-boot.img")
+    f_lxc_boot=$(find /lava-lxc -type f -name "*boot.img" -a -not -name "*vendor_boot.img")
+    f_docker_boot=$(find /lava-downloads -type f -name "*boot.img" -a -not -name "*vendor_boot.img")
     if [ -n "${f_lxc_boot}" ] && [ -f "${f_lxc_boot}" ]; then
         # for lxc container method
         fastboot boot "${f_lxc_boot}"


### PR DESCRIPTION
but with the vendor_boot.img excluded

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>