### PR TITLE
automated: linux: add mmtests benchmarks

### DIFF
--- a/automated/linux/mmtests/json-to-lava.py
+++ b/automated/linux/mmtests/json-to-lava.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+
+# Converts mmtests test results from JSON format to a list of strings
+# with the following structure so LAVA can understand it:
+# <module_name>-<test_name>-<op>-<iteration>-<sample> pass <value>
+
+import argparse
+import json
+
+
+def main(args):
+    exitcode = 0
+    with open(args.json_file) as f:
+        module = json.load(f)
+        module_name = module["_ModuleName"].replace("Extract", "").lower()
+        test_name = module["_TestName"]
+        data = module["_ResultData"]
+        operations = list(data)
+        iterations = len(data[operations[0]])
+        for i in range(iterations):
+            for op in operations:
+                op_data = data[op][i]
+                values = op_data["Values"]
+                samples = op_data["SampleNrs"]
+                for val, sample in zip(values, samples):
+                    print(f"{module_name}-{test_name}-{op}-{i}-{sample} pass {val}")
+    exit(exitcode)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Formats mmtests loadable json to lava results format"
+    )
+    parser.add_argument(
+        "json_file",
+        type=str,
+        nargs="?",
+        help="JSON file to convert in a test result acceptable for lava",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/automated/linux/mmtests/mmtests.sh
+++ b/automated/linux/mmtests/mmtests.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Sysbench is a modular, cross-platform and multi-threaded benchmark tool.
+# This runs the CPU microbench which calculates primes up to a
+# certain value using varying numbers of instances.
+# In this configuration, it calculates primes up to 25000
+# using between 1 and 2*NUMCPUS threads.
+
+# shellcheck disable=SC1091
+. ../../lib/sh-test-lib
+
+OUTPUT="$(pwd)/output"
+TEST_PROGRAM="mmtests"
+TEST_PROG_VERSION=
+TEST_GIT_URL=https://github.com/gormanm/mmtests
+TEST_DIR="$(pwd)/${TEST_PROGRAM}"
+SKIP_INSTALL="false"
+MMTESTS_MAX_RETRIES=10
+MMTESTS_TYPE_NAME=
+MMTESTS_CONFIG_FILE=
+
+usage() {
+	echo "\
+	Usage: $0 [-s <true|false>] [-v <TEST_PROG_VERSION>]
+			[-u <TEST_GIT_URL>] [-p <TEST_DIR>]
+			[-c <MMTESTS_CONFIG_FILE>] [-t <MMTESTS_TYPE_NAME>] [-r <MMTESTS_MAX_RETRIES>]
+
+	<TEST_PROG_VERSION>:
+	If this parameter is set, then the ${TEST_PROGRAM} suite is cloned. In
+	particular, the version of the suite is set to the commit
+	pointed to by the parameter. A simple choice for the value of
+	the parameter is, e.g., HEAD. If, instead, the parameter is
+	not set, then the suite present in TEST_DIR is used.
+
+	<TEST_GIT_URL>:
+	If this parameter is set, then the ${TEST_PROGRAM} suite is cloned
+	from the URL in TEST_GIT_URL. Otherwise it is cloned from the
+	standard repository for the suite. Note that cloning is done
+	only if TEST_PROG_VERSION is not empty
+
+	<TEST_DIR>:
+	If this parameter is set, then the ${TEST_PROGRAM} suite is cloned to or
+	looked for in TEST_DIR. Otherwise it is cloned to $(pwd)/${TEST_PROGRAM}
+
+	<SKIP_INSTALL>:
+	If you already have it installed into the rootfs.
+	default: false
+
+	<MMTESTS_CONFIG_FILE>:
+	Mmtests configuration file that describes how the benchmarks should be
+	configured and executed.
+
+	<MMTESTS_TYPE_NAME>:
+	Mtests test type, e.g. sysbenchcpu, iozone, sqlite, etc.
+
+	<MMTESTS_MAX_RETRIES>:
+	Maximum number of retries for the single benchamrk's source file download"
+	exit 1
+}
+
+while getopts "c:p:r:s:t:u:v:" opt; do
+	case "${opt}" in
+		c)
+			MMTESTS_CONFIG_FILE="${OPTARG}"
+			;;
+		p)
+			if [[ "$OPTARG" != '' ]]; then
+				TEST_DIR="$OPTARG"
+			fi
+			;;
+		r)
+			MMTESTS_MAX_RETRIES="${OPTARG}"
+			;;
+		s)
+			SKIP_INSTALL="${OPTARG}"
+			;;
+		t)
+			MMTESTS_TYPE_NAME="${OPTARG}"
+			;;
+		u)
+			if [[ "$OPTARG" != '' ]]; then
+				TEST_GIT_URL="$OPTARG"
+			fi
+			;;
+		v)
+			TEST_PROG_VERSION="$OPTARG"
+			;;
+		*)
+			usage
+			;;
+	esac
+done
+
+install() {
+	dist=
+	dist_name
+	case "${dist}" in
+	debian|ubuntu)
+			pkgs="build-essential wget perl git autoconf automake \
+					bc binutils-dev btrfs-progs linux-cpupower expect \
+					gcc hdparm hwloc-nox libtool numactl tcl time \
+					xfsprogs xfslibs-dev libopenmpi-dev"
+			install_deps "${pkgs}" "${SKIP_INSTALL}"
+		;;
+	fedora|centos)
+		pkgs="git gcc make automake libtool wget perl autoconf \
+					bc binutils-devel btrfs-progs kernel-tools expect \
+					hdparm hwloc libtool numactl tcl time xfsprogs \
+					openmpi-devel"
+			install_deps "${pkgs}" "${SKIP_INSTALL}"
+		;;
+	oe-rpb)
+		# Assume all dependent packages are already installed.
+		;;
+	*)
+		warn_msg "Unsupported distro: ${dist}! Package installation skipped!"
+		;;
+	esac
+}
+
+prepare_system() {
+	pushd "${TEST_DIR}" || exit
+	PERL_MM_USE_DEFAULT=1
+	export PERL_MM_USE_DEFAULT
+	cpan -F JSON Cpanel::JSON::XS List::BinarySearch
+	AUTO_PACKAGE_INSTALL=yes
+	export AUTO_PACKAGE_INSTALL
+	DOWNLOADED=0
+	COUNTER=0
+	while [ $DOWNLOADED -eq 0 ] && [ $COUNTER -lt "$MMTESTS_MAX_RETRIES" ]; do
+		./run-mmtests.sh -b --no-monitor --config "${MMTESTS_CONFIG_FILE}" benchmark && DOWNLOADED=1
+		COUNTER=$((COUNTER+1))
+	done
+	popd || exit
+}
+
+run_test() {
+	pushd "${TEST_DIR}" || exit
+	info_msg "Running ${MMTESTS_TYPE_NAME} cpu test..."
+	extracted_json="../${MMTESTS_TYPE_NAME}.json"
+	./run-mmtests.sh --no-monitor --config "${MMTESTS_CONFIG_FILE}" benchmark
+	./bin/extract-mmtests.pl -d work/log/ -b "${MMTESTS_TYPE_NAME}" -n benchmark --print-json > "$extracted_json"
+	popd || exit
+}
+
+! check_root && error_msg "Please run this script as root."
+
+# Test installation.
+if [ "${SKIP_INSTALL}" = "true" ] || [ "${SKIP_INSTALL}" = "True" ]; then
+	info_msg "${MMTESTS_TYPE_NAME} installation skipped"
+else
+	install
+fi
+
+get_test_program "${TEST_GIT_URL}" "${TEST_DIR}" "${TEST_PROG_VERSION}" "${TEST_PROGRAM}"
+
+create_out_dir "${OUTPUT}"
+prepare_system
+run_test

--- a/automated/linux/mmtests/mmtests.yaml
+++ b/automated/linux/mmtests/mmtests.yaml
@@ -1,0 +1,49 @@
+metadata:
+    name: mmtests
+    format: "Lava-Test Test Definition 1.0"
+    description: "MMTests is a configurable test suite that runs performance tests
+                  against arbitrary workloads. This is not the only test framework
+                  but care is taken to make sure the test configurations are accurate,
+                  representative and reproducible. Reporting and analysis is common across
+                  all benchmarks. Support exists for gathering additional telemetry while
+                  tests are running and hooks exist for more detailed tracing using ftrace
+                  or perf."
+
+params:
+    # Skips the installation of mmtests
+    SKIP_INSTALL: "false"
+
+    # If the following parameter is set, then the mmtests suite is
+    # cloned and used unconditionally. In particular, the version
+    # of the suite is set to the commit pointed to by the
+    # parameter. A simple choice for the value of the parameter
+    # is, e.g., HEAD.  If, instead, the parameter is
+    # not set, then the suite present in TEST_DIR is used.
+    TEST_PROG_VERSION: "HEAD"
+
+    # If next parameter is set, then the mmtests suite is cloned
+    # from the URL in TEST_GIT_URL. Otherwise it is cloned from the
+    # standard repository for the suite. Note that cloning is done
+    # only if TEST_PROG_VERSION is not empty.
+    TEST_GIT_URL: "https://github.com/gormanm/mmtests"
+
+    # If next parameter is set, then the mmtests suite is cloned to or
+    # looked for in TEST_DIR. Otherwise it is cloned to $(pwd)/mmtests
+    TEST_DIR: ""
+
+    # Mtests test type, e.g. sysbenchcpu, iozone, sqlite, etc.
+    MMTESTS_TYPE_NAME: "sqlite"
+
+    # Mmtests configuration file that describes how the benchmarks should be
+    # configured and executed.
+    MMTESTS_CONFIG_FILE: "configs/config-db-sqlite-insert-small"
+
+    # Maximum number of retries for the single benchmark source file download
+    MMTESTS_MAX_RETRIES: 10
+
+run:
+    steps:
+        - cd ./automated/linux/mmtests/
+        - ./mmtests.sh -s "${SKIP_INSTALL}" -v "${TEST_PROG_VERSION}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}" -c "${MMTESTS_CONFIG_FILE}" -t "${MMTESTS_TYPE_NAME}" -r ${MMTESTS_MAX_RETRIES}
+        - ./json-to-lava.py "./${MMTESTS_TYPE_NAME}.json" > ./output/result.txt
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
MMTests is a configurable test suite that runs performance tests
against arbitrary workloads.

This commit adds to the test set the mmtests suite and exports
the test results in a JSON file.

Signed-off-by: Mirco Romagnoli <romagnoli.mirco@gmail.com>