### PR TITLE
Fix artifacts publishing with busybox

### DIFF
--- a/automated/utils/upload-to-artifactorial.sh
+++ b/automated/utils/upload-to-artifactorial.sh
@@ -40,7 +40,7 @@ fi
 if which lava-test-reference; then
     # If 'ARTIFACTORIAL_TOKEN' defined in 'secrects' dictionary defined in job
     # definition file, it will be used.
-    lava_test_dir="$(find /lava-* -maxdepth 0 -type d -regex '/lava-[0-9]+' 2>/dev/null | sort | tail -1)"
+    lava_test_dir="$(find /lava-* -maxdepth 0 -type d | grep -E '^/lava-[0-9]+' 2>/dev/null | sort | tail -1)"
     if test -f "${lava_test_dir}/secrets" && grep -q "ARTIFACTORIAL_TOKEN" "${lava_test_dir}/secrets"; then
         # shellcheck disable=SC1090
         . "${lava_test_dir}/secrets"


### PR DESCRIPTION
Busybox find command with argument '-regex' doesn't work, use 'grep -E'
instead for pattern filtering.

Signed-off-by: Chase Qi <chase.qi@linaro.org>