### PR TITLE
mmtests: mmtests.yaml: add mandatory keywords maintainer, os and devices

### DIFF
--- a/automated/linux/mmtests/mmtests.yaml
+++ b/automated/linux/mmtests/mmtests.yaml
@@ -8,7 +8,14 @@ metadata:
                   all benchmarks. Support exists for gathering additional telemetry while
                   tests are running and hooks exist for more detailed tracing using ftrace
                   or perf."
-
+    maintainer:
+        - anders.roxell@linaro.org
+        - naresh.kamboju@linaro.org
+        - romagnoli.mirco@gmail.com
+    os:
+        - debian
+    devices:
+        - juno-r2
 params:
     # Skips the installation of mmtests
     SKIP_INSTALL: "false"


### PR DESCRIPTION
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>