### PR TITLE
automated: linux: fix kernel-config-checker results

### DIFF
--- a/automated/linux/kernel-config-checker/kernel-config-checker.sh
+++ b/automated/linux/kernel-config-checker/kernel-config-checker.sh
@@ -76,7 +76,7 @@ check_config() {
     for c in ${@}; do
         info_msg "Checking config option ${c}..."
         cat < "${kernel_config}" | grep "${c}=[y|m]" > /dev/null
-        check_return "config value: ${c}"
+        check_return "config_value_${c}"
     done
 }
 


### PR DESCRIPTION
Results reported with check_return should not include white spaces and
semi-colons.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>