### PR TITLE
noninteractive-tradefed/setup.sh: make sure the correct java version …

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -6,9 +6,11 @@
 . ../../lib/android-test-lib
 
 JDK="openjdk-8-jdk-headless"
+java_path="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
 if [ -n "${ANDROID_VERSION}" ] && echo "${ANDROID_VERSION}" | grep -q  "aosp-master"; then
     # only use openjdk-11 for aosp master version
     JDK="openjdk-11-jdk-headless"
+    java_path="/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
 #elif 8.1/9.0/android10
 #   JDK="openjdk-8-jdk-headless"
 fi
@@ -21,6 +23,8 @@ case "${dist}" in
         dpkg --add-architecture i386
         apt-get update -q
         install_deps "${PKG_DEPS} ${JDK}"
+        # make sure to use the right java version
+        update-alternatives --set java ${java_path}
         ;;
     *)
         error_msg "Please use Ubuntu for CTS or VTS test."


### PR DESCRIPTION
…is used

when both openjdk11 and openjdk8 are installed, the openjdk11 will be used by default.
so we need to set the java version explicitly

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>