### PR TITLE
Remove extra whitespace in the value of variable 'r'

### DIFF
--- a/automated/linux/rt-migrate-test/rt-migrate-test.sh
+++ b/automated/linux/rt-migrate-test/rt-migrate-test.sh
@@ -43,7 +43,7 @@ background_process_stop bgcmd
 
 # Parse test log.
 task_num=$(grep "Task" "${LOGFILE}" | tail -1 | awk '{print $2}')
-r=$(sed -n 's/Passed!/pass/p; s/Failed!/fail/p' "${LOGFILE}")
+r=$(sed -n 's/Passed!/pass/p; s/Failed!/fail/p' "${LOGFILE}" | awk '{$1=$1;print}')
 for t in $(seq 0 "${task_num}"); do
     # Get the priority of the task.
     p=$(grep "Task $t" "${LOGFILE}" | awk '{print substr($4,1,length($4)-1)}')


### PR DESCRIPTION
The variable 'r' contains " pass" value with an extra whitespace added.
To keep the results in an organized manner, extra whitespace should be avoided
in between columns of result.txt file.

Signed-off-by: Vidyasagar G C <vidyasagar_gc@mentor.com>