### PR TITLE
Fix kunit

### DIFF
--- a/automated/linux/kunit/kunit.sh
+++ b/automated/linux/kunit/kunit.sh
@@ -91,11 +91,11 @@ then
     KERNEL_CONFIG_FILE="/boot/config-$(uname -r)"
     CONFIG_KUNIT_TEST=$(grep "CONFIG_KUNIT_TEST=" "${KERNEL_CONFIG_FILE}")
 else
-    exit_on_skip "kunit-pre-requirements" "Kernel config file not available"
+    info_msg"Kernel config file not available"
 fi
 if [ "${CONFIG_KUNIT_TEST}" = "CONFIG_KUNIT_TEST=y" ]
 then
-    exit_on_skip "kunit-pre-requirements" "Kernel config CONFIG_KUNIT_TEST=y not enabled"
+    info_msg "Kernel config CONFIG_KUNIT_TEST=y not enabled"
 fi
 
 run "${TEST_CMD}"

--- a/automated/linux/kunit/kunit.yaml
+++ b/automated/linux/kunit/kunit.yaml
@@ -22,8 +22,9 @@ metadata:
         - x86
 
 params:
-    # Example: kunit-test.ko
-    KUNIT_TEST_MODULE: ""
+    # This will try to find all modules that ends with '*test.ko'
+    # Example: test.ko
+    KUNIT_TEST_MODULE: "test.ko"
 
 run:
     steps:


### PR DESCRIPTION
This makes it possible to find all modules that ends with 'test.ko'.
Also fix so we dont fail if we can't find the config file.