### PR TITLE
LTP: Skip ping01 on juno-r2 for 4.4 branch

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -342,3 +342,17 @@ skiplist:
       - all
     tests:
       - ping602
+
+  - reason: >
+      LTP ping01 added into smoketest in the latest release
+      which is not supported on Juno running 4.4 kernel.
+    url: https://bugs.linaro.org/show_bug.cgi?id=5799
+    environments: production
+    boards:
+      - juno-r2
+    branches:
+      - 4.4
+      - linux-4.4.y
+      - v4.4-rt
+    tests:
+      - ping01


### PR DESCRIPTION
LTP smoketest ping01 not supported on juno-r2 running on 4.4 branch.

module veth: overflow in relocation type 261 val ffffffbffc000000
RTNETLINK answers: Operation not supported
ping01 1 TBROK: ip link add name ltp_ns_veth1 type veth peer name ltp_ns_veth2 failed

Signed-off-by: Naresh Kamboju <naresh.kamboju@linaro.org>