### PR TITLE
noninteractive-tradefed: support more ANDROID_VERSION

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -7,7 +7,7 @@
 
 JDK="openjdk-8-jdk-headless"
 java_path="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
-if [ -n "${ANDROID_VERSION}" ] && echo "${ANDROID_VERSION}" | grep -q  "aosp-master"; then
+if [ -n "${ANDROID_VERSION}" ] && echo "${ANDROID_VERSION}" | grep -q  "aosp-master\|aosp-android11\|aosp-android12"; then
     # only use openjdk-11 for aosp master version
     JDK="openjdk-11-jdk-headless"
     java_path="/usr/lib/jvm/java-11-openjdk-amd64/bin/java"


### PR DESCRIPTION
to work with aosp-android11, aosp-android12 too

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>