### PR TITLE
mmtests: export multiple json files into lava format

### DIFF
--- a/automated/linux/mmtests/json-to-lava.py
+++ b/automated/linux/mmtests/json-to-lava.py
@@ -2,10 +2,12 @@
 
 # Converts mmtests test results from JSON format to a list of strings
 # with the following structure so LAVA can understand it:
-# <module_name>-<test_name>-<op>-<iteration>-<sample> pass <value>
+# <module_name>_<op>_<iteration>_<sample> pass <value>
+# <module_name>_<$field>_<none>_<value> pass <0>
 
 import argparse
 import json
+from base64 import b64encode
 
 
 def main(args):
@@ -13,7 +15,6 @@ def main(args):
     with open(args.json_file) as f:
         module = json.load(f)
         module_name = module["_ModuleName"].replace("Extract", "").lower()
-        test_name = module["_TestName"]
         data = module["_ResultData"]
         operations = list(data)
         iterations = len(data[operations[0]])
@@ -22,8 +23,15 @@ def main(args):
                 op_data = data[op][i]
                 values = op_data["Values"]
                 samples = op_data["SampleNrs"]
+                op.replace("_", "-")
                 for val, sample in zip(values, samples):
-                    print(f"{module_name}-{test_name}-{op}-{i}-{sample} pass {val}")
+                    print(f"{module_name}_{op}_{i}_{sample} pass {val}")
+        if "_Cmd" in module:
+            string = ""
+            for i in range(len(module["_Cmd"])):
+                string = string + module["_Cmd"][i]
+            b64string = b64encode(bytes(string, "utf-8")).decode("utf-8")
+            print(f"{module_name}_$Cmd_0_{b64string} pass {0}")
     exit(exitcode)
 
 

--- a/automated/linux/mmtests/mmtests.sh
+++ b/automated/linux/mmtests/mmtests.sh
@@ -18,6 +18,8 @@ MMTESTS_MAX_RETRIES=10
 MMTESTS_TYPE_NAME=
 MMTESTS_CONFIG_FILE=
 
+declare -A altreport_mappings=( ["dbench4"]="tput latency opslatency")
+
 usage() {
 	echo "\
 	Usage: $0 [-s <true|false>] [-v <TEST_PROG_VERSION>]
@@ -135,10 +137,15 @@ prepare_system() {
 
 run_test() {
 	pushd "${TEST_DIR}" || exit
-	info_msg "Running ${MMTESTS_TYPE_NAME} cpu test..."
+	info_msg "Running ${MMTESTS_TYPE_NAME} test..."
 	extracted_json="../${MMTESTS_TYPE_NAME}.json"
 	./run-mmtests.sh --no-monitor --config "${MMTESTS_CONFIG_FILE}" benchmark
 	./bin/extract-mmtests.pl -d work/log/ -b "${MMTESTS_TYPE_NAME}" -n benchmark --print-json > "$extracted_json"
+	altreports=${altreport_mappings[${MMTESTS_TYPE_NAME}]}
+	for altreport in ${altreports}; do
+		./bin/extract-mmtests.pl -d work/log/ -b "${MMTESTS_TYPE_NAME}" -n benchmark\
+		-a "${altreport}" --print-json > "../${MMTESTS_TYPE_NAME}_${altreport}.json"
+	done
 	popd || exit
 }
 

--- a/automated/linux/mmtests/mmtests.yaml
+++ b/automated/linux/mmtests/mmtests.yaml
@@ -52,5 +52,6 @@ run:
     steps:
         - cd ./automated/linux/mmtests/
         - ./mmtests.sh -s "${SKIP_INSTALL}" -v "${TEST_PROG_VERSION}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}" -c "${MMTESTS_CONFIG_FILE}" -t "${MMTESTS_TYPE_NAME}" -r ${MMTESTS_MAX_RETRIES}
-        - ./json-to-lava.py "./${MMTESTS_TYPE_NAME}.json" > ./output/result.txt
+        - if [ ! -z ${TEST_DIR} ]; then mv ${TEST_DIR}/../${MMTESTS_TYPE_NAME}*.json .; fi
+        - for file in ./${MMTESTS_TYPE_NAME}*.json; do ./json-to-lava.py $file >> ./output/result.txt; done
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
mmtests/json-to-lava: add support for altreports and multiple json files

Change the structure of the LAVA data to push to squad as following:
  <module_name>;<op>;<iteration>;<sample> pass <value>

The test name field in the second position had been dropped, since the
name of the origin folder is always something generic like "benchmark",
therefore useless

The <op> field now has a double function. If not prefixed with an "_",
it represent the operation which generated the relative data, as it was before.
If the content starts with "_", it now represent additional data to add
at the top level of the corresponding json file.
E.g, the line:
  dbench4tput;_Cmd;0;b'ZGJlbmNoIC1EIC9ob2 ... lLXRpbWUgMQo=' pass 0
represent the _Cmd field in the json, which data in the <sample> spot
can be decoded from b64 to obtain the original command string.

mmtests/mmtests.sh: add an associative array, in which the altreports
to be exported into LAVA must be added for each test case.
If only the main report is available for any testcase, there is no need
to add anything to the altreport_mappings array.

Signed-off-by: Federico Gelmetti <federico.gelmo@gmail.com>