### PR TITLE
automated: cleanup target after remote testing

### DIFF
--- a/automated/utils/test-runner.py
+++ b/automated/utils/test-runner.py
@@ -470,6 +470,10 @@ class RemoteTestRun(AutomatedTestRun):
             "rm %s/%s" % (self.test["target_test_path"], tarball_name), self.args.target
         )
 
+    def cleanup_target(self):
+        self.logger.info("Removing files from target after testing")
+        run_command("rm -rf %s" % (self.test["target_test_path"]), self.args.target)
+
     def run(self):
         self.copy_to_target()
         self.logger.info(
@@ -486,6 +490,7 @@ class RemoteTestRun(AutomatedTestRun):
         self.child = pexpect.spawnu(shell_cmd)
         self.child.logfile = output
         self.check_result()
+        self.cleanup_target()
 
 
 class ManualTestShell(cmd.Cmd):


### PR DESCRIPTION
test-runner will call "rm -rf" on the directory it created temporarily
on the remote target. This should remove all residual files created in
the process of running a test.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>