### PR TITLE
automated: fix IMA test to avoid using dmesg

### DIFF
--- a/automated/linux/ima/ima.sh
+++ b/automated/linux/ima/ima.sh
@@ -64,8 +64,18 @@ info_msg "Output directory: ${OUTPUT}"
 check_config "${CONFIG_VALUES}"
 
 # check dmesg for IMA initialization
-dmesg | grep "ima: policy update completed"
-check_return "ima_initialization"
+# checking if policy file exists works in scenario
+# when the appropriate message is removed from dmesg
+if [ -f /sys/kernel/security/ima/policy ]; then
+    POLICY="$(cat /sys/kernel/security/ima/policy)"
+    if [ -n "${POLICY}" ]; then
+        report_pass "ima_initialization"
+    else
+        report_fail "ima_initialization"
+    fi
+else
+    report_fail "ima_initialization"
+fi
 
 # check if checksum files is present
 test_name="ima_runtime_measurements"


### PR DESCRIPTION
When IMA test is executed a long time after the boot, the initialization
message might already be gone from dmesg buffer. In this case the test
will falsly report 'fail' result. This patch fixes the issue by checking
if the actual policy file exists on the sysfs.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>