### PR TITLE
noninteractive-tradefed: support to run under powersave governor policy

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -34,3 +34,11 @@ esac
 install_latest_adb
 initialize_adb
 adb_root
+
+if echo "X${SET_GOVERNOR_POWERSAVE}" | grep -i "Xtrue"; then
+    echo "Set the device to be run with the powersave governor policy"
+    for f_cpu_governor in $(adb shell 'su root ls /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor'); do
+        adb shell "echo powersave | su root tee ${f_cpu_governor}"
+    done
+    adb shell 'su root cat /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor'
+fi

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -39,6 +39,9 @@ params:
     # aosp-master version needs to use openjdk-11, other older versions needs to use openjdk-8
     # for aosp master version, the value of ANDROID_VERSION must have aosp-master in its value
     ANDROID_VERSION: ""
+    # when we need to set the DUT to be run in the powersave governor policy
+    # to avoid shutting down by high temperature when run the cts vts test
+    SET_GOVERNOR_POWERSAVE: "false"
 
 run:
     steps:


### PR DESCRIPTION
to avoid the shutdown of device caused high temperature
when run the cts vts jobs

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>