### PR TITLE
automated: linux: add timesyncd NTP sync test

### DIFF
--- a/automated/linux/timesyncd/timesyncd.yaml
+++ b/automated/linux/timesyncd/timesyncd.yaml
@@ -1,0 +1,31 @@
+metadata:
+    name: timesyncd-test
+    format: "Lava-Test Test Definition 1.0"
+    description: "The test checks whether the systemd-timesyncd is
+        running and uses NTP. It should only be used when it's expected
+        to use NTP. As an additional check the test will contact default
+        NTP server to check whether the time is synced properly."
+    maintainer:
+        - milosz.wasilewski@foundries.io
+    os:
+        - debian
+        - ubuntu
+        - fedora
+        - centos
+    scope:
+        - functional
+    environment:
+        - lava-test-shell
+    devices:
+        - hi6220-hikey
+        - apq8016-sbc
+        - imx8mmevk
+        - imx6ullevk
+params:
+    NTP_SERVER: "pool.ntp.org"
+    SKIP_INSTALL: "true"
+run:
+    steps:
+        - cd ./automated/linux/timesyncd/
+        - ./timesynctest.sh -n "${NTP_SERVER}" -s "${SKIP_INSTALL}"
+        - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/timesyncd/timesynctest.py
+++ b/automated/linux/timesyncd/timesynctest.py
@@ -1,0 +1,38 @@
+import argparse
+import sys
+from time import ctime
+from datetime import datetime
+
+try:
+    import ntplib
+except ImportError:
+    print("ntplib missing")
+    sys.exit(1)
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-n",
+    "--ntp-server",
+    dest="ntp_server",
+    default="pool.ntp.org",
+    help="NTP server to check against",
+)
+args = parser.parse_args()
+c = ntplib.NTPClient()
+response = None
+try:
+    response = c.request(args.ntp_server)
+except ntplib.NTPException:
+    print(f"Unable to contact {args.ntp_server}")
+    sys.exit(2)
+
+ntp_time = datetime.fromtimestamp(response.tx_time)
+local_time = datetime.now()
+time_diff = local_time - ntp_time
+if abs(time_diff.total_seconds()) > 1:
+    # test fails
+    print(f"NTP Time: {ntp_time}")
+    print(f"Local Time: {local_time}")
+    print(f"Time difference: {time_diff}")
+    sys.exit(1)
+sys.exit(0)

--- a/automated/linux/timesyncd/timesynctest.sh
+++ b/automated/linux/timesyncd/timesynctest.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+#
+# systemd-timesyncd test
+#
+# Copyright (C) 2021, Foundries.io
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+# shellcheck disable=SC1091
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+export RESULT_FILE
+SKIP_INSTALL="true"
+NTP_SERVER="pool.ntp.org"
+
+usage() {
+    echo "Usage: $0 [-n ntpserver] [-s <true|false>]" 1>&2
+    exit 1
+}
+
+while getopts "s:n:h" o; do
+    case "$o" in
+        n) NTP_SERVER="${OPTARG}" ;;
+        s) SKIP_INSTALL="${OPTARG}" ;;
+        h|*) usage ;;
+    esac
+done
+
+! check_root && error_msg "You need to be root to run this script."
+
+if [ "$SKIP_INSTALL" = 'true' ] || [ "$SKIP_INSTALL" = 'True' ]; then
+    warn_msg "Dependencies for timesyncd test installation skipped!"
+else
+    install_deps "python3-pip"
+fi
+
+# Test run.
+create_out_dir "${OUTPUT}"
+
+timedatectl show -p CanNTP --value | grep "yes"
+check_return "timesyncd-canntp"
+timedatectl show -p NTP --value | grep "yes"
+check_return "timesyncd-ntp"
+timedatectl show -p NTPSynchronized --value | grep "yes"
+check_return "timesyncd-ntpsynchronized"
+
+# check if local time is the same a served by NTP
+# ignore failure in package installation
+# should this happen the script will fail gracefully
+python3 -m pip install --user ntplib || true
+python3 timesynctest.py -n "${NTP_SERVER}"
+check_return "timesyncd-systemtime"


### PR DESCRIPTION
This test checks whether timesyncd is running and synchronizing to NTP
server. As additional check reference NTP server's time is compared with
local system time.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>