### PR TITLE
ltp: fix fedora package dependency 'au'

### DIFF
--- a/automated/linux/ltp/ltp.sh
+++ b/automated/linux/ltp/ltp.sh
@@ -214,7 +214,7 @@ install() {
         ;;
       centos|fedora)
         [[ -n "${TEST_GIT_URL}" ]] && pkgs="git-core"
-        pkgs="${pkgs} xz flex bison make automake gcc gcc-c++ kernel-devel wget curl net-tools quota genisoimage sudo libaio-devel libattr-devel libcap-devel m4 au expect acl pkgconf"
+        pkgs="${pkgs} xz flex bison make automake gcc gcc-c++ kernel-devel wget curl net-tools quota genisoimage sudo libaio-devel libattr-devel libcap-devel m4 expect acl pkgconf"
         install_deps "${pkgs}" "${SKIP_INSTALL}"
         ;;
       *)


### PR DESCRIPTION
The package 'au' was probably added by mistake since.

'No match for argument: au'

Remove the faulty package 'au' from fedora.

Fixes: 67acee6c1a53 ("automated: linux: ltp: incorporate building LTP from git")
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>