### PR TITLE
mmtests: add config settings in the exported LAVA output

### DIFF
--- a/automated/linux/mmtests/json-to-lava.py
+++ b/automated/linux/mmtests/json-to-lava.py
@@ -26,12 +26,23 @@ def main(args):
                 op.replace("_", "-")
                 for val, sample in zip(values, samples):
                     print(f"{module_name}_{op}_{i}_{sample} pass {val}")
-        if "_Cmd" in module:
-            string = ""
-            for i in range(len(module["_Cmd"])):
-                string = string + module["_Cmd"][i]
-            b64string = b64encode(bytes(string, "utf-8")).decode("utf-8")
-            print(f"{module_name}_$Cmd_0_{b64string} pass {0}")
+        for key, value in module.items():
+            if key.startswith("_Cmd"):
+                string = ""
+                for i in range(len(module["_Cmd"])):
+                    string = string + module["_Cmd"][i]
+                b64string = (
+                    b64encode(bytes(string, "utf-8")).decode("utf-8").replace("=", "")
+                )
+                chunk_size = 25
+                string_split = [
+                    b64string[i : i + chunk_size]
+                    for i in range(0, len(b64string), chunk_size)
+                ]
+                for i in range(len(string_split)):
+                    print(f"{module_name}_#Cmd_{i}_{string_split[i]} pass {0}")
+            if key.startswith("CONFIG-"):
+                print(f"{module_name}_#{key}_0_{value} pass {0}")
     exit(exitcode)
 
 

--- a/sanity-check.sh
+++ b/sanity-check.sh
@@ -3,11 +3,14 @@ set -ex
 
 python3 validate.py \
     -r build-error.txt \
-    -p E501 W503 \
+    -p E501 W503 E203 \
     -s SC1091 SC2230
 
 # pycodestyle checks skipped:
-# E510: line too long
+# E501: line too long
+# E203: Whitespace before ':'
+#   Disabled because conflicting with black, refer to the link for details
+#   https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#slices
 
 # Shellchecks skipped:
 # SC1091: not following


### PR DESCRIPTION
Since the env variables used in mmtests to perform each specific
test change based on the evironment and the test itself, we
want to save those config in SQUAD as well, to be retrieved
later by the reporting tool.

In order to do so, an associative array is needed to retrieve the
correct env variables for each test, since the name of said variables
does not always start with the name of the tests.

The syntax follows the one used previosly for the other
additional parameters:

	dbench4_#CONFIG-DBENCH-DURATION-BASE_0_30 pass 0
	dbench4_#CONFIG-DBENCH-FSYNC_0_no pass 0
	dbench4_#CONFIG-DBENCH-MAX-CLIENTS_0_1 pass 0

json-to-lava.py: split the command string in pieces of 25
    characters, in order to avoid LAVA breaking with strings too long

Signed-off-by: Federico Gelmetti <federico.gelmo@gmail.com>