### PR TITLE
automated: linux: remove docker container after the test

### DIFF
--- a/automated/linux/docker/docker.sh
+++ b/automated/linux/docker/docker.sh
@@ -51,10 +51,10 @@ exit_on_fail "start-docker-service" "${skip_list}"
 
 case "${IMAGE}" in
     hello-world)
-        docker run "${IMAGE}"
+        docker run --rm "${IMAGE}"
         ;;
     *)
-        docker run -it "${IMAGE}" /bin/echo "Hello Docker"
+        docker run --rm "${IMAGE}" /bin/echo "Hello Docker"
         ;;
 esac
 check_return "run-docker-image"


### PR DESCRIPTION
When running basic docker test, the container is left in the stopped
state after the execution completes. This patch forces docker to
remove the container.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>