### PR TITLE
mmtests: adapt for workloads with multiple subtests

### DIFF
--- a/automated/linux/mmtests/json-to-lava.py
+++ b/automated/linux/mmtests/json-to-lava.py
@@ -23,9 +23,9 @@ def main(args):
                 op_data = data[op][i]
                 values = op_data["Values"]
                 samples = op_data["SampleNrs"]
-                op.replace("_", "-")
+                op_formatted = op.replace("_", "-").replace("/", "-")
                 for val, sample in zip(values, samples):
-                    print(f"{module_name}_{op}_{i}_{sample} pass {val}")
+                    print(f"{module_name}_{op_formatted}_{i}_{sample} pass {val}")
         for key, value in module.items():
             if key.startswith("_Cmd"):
                 string = ""


### PR DESCRIPTION
mmtests.sh: adapt for correct generation of json files
when the workload supplied is composed by more than one benchmark,
as in the case of workload-aim9-pagealloc

json-to-lava: fix incorrect LAVA output when supplied with
operation names containing "/"

Signed-off-by: Federico Gelmetti <federico.gelmo@gmail.com>