### PR TITLE
automated: linux: add more checks to wlan-download

### DIFF
--- a/automated/linux/wlan-download/wlan-download-test.sh
+++ b/automated/linux/wlan-download/wlan-download-test.sh
@@ -168,16 +168,33 @@ create_out_dir "${OUTPUT}"
 info_msg "About to run wlan download test..."
 info_msg "Output directory: ${OUTPUT}"
 
-if [ -n "${ETHERNET_DEVICE}" ]; then
-    ip link set "${ETHERNET_DEVICE}" down
-    check_return "eth-down"
+# check if DEVICE matches any existing network interface
+if [ ! -L "/sys/class/net/${DEVICE}" ]; then
+    # exit with skiplist
+    exit_on_fail "wlan-device-exists" "wlan-device-wireless eth-down wlan-scan wlan-connect wlan-ip-address wlan-ping wlan-download wland-download-checksum wlan-disconnect eth-up"
+else
+    report_pass "wlan-device-exists"
+fi
+
+# check if DEVICE is a wireless device
+if [ ! -d "/sys/class/net/${DEVICE}/wireless" ]; then
+    # exit with skiplist
+    exit_on_fail "wlan-device-wireless" "eth-down wlan-scan wlan-connect wlan-ip-address wlan-ping wlan-download wland-download-checksum wlan-disconnect eth-up"
+else
+    report_pass "wlan-device-wireless"
 fi
 
 systemctl stop wpa_supplicant # to don't interfere with our wpa_supplicant instance
 ip link set "${DEVICE}" up
 sleep "${TIME_DELAY}" # XXX: some devices needs a wait after up to be ready, default: 0s
 iw dev "${DEVICE}" scan
-exit_on_fail "wlan-scan"
+exit_on_fail "wlan-scan" "eth-down wlan-connect wlan-ip-address wlan-ping wlan-download wland-download-checksum wlan-disconnect eth-up"
+
+if [ -n "${ETHERNET_DEVICE}" ]; then
+    ip link set "${ETHERNET_DEVICE}" down
+    check_return "eth-down"
+fi
+
 test_wlan_connection
 if [ -n "${FILE_URL}" ]; then
     test_wlan_download


### PR DESCRIPTION
Wlan-download test will misbehave in case the requested wireless
interface doesn't exist. This patch fixes the issue and prevents
unexpected ETH interface down time. In addition skiplists are added to
provide full list of expected tests in all circumstances

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>