### PR TITLE
automated: linux: force clean exit from aklite test

### DIFF
--- a/automated/linux/disable-aklite-reboot/disable-aklite-reboot.sh
+++ b/automated/linux/disable-aklite-reboot/disable-aklite-reboot.sh
@@ -17,5 +17,13 @@ report_pass "create-aklite-toml"
 
 systemctl enable --now lmp-device-auto-register
 
+# the below aklite status call is added for debugging
+# aklite should take it's config from the .toml file and the
+# following should be included in the output:
+#    info: Reading config: \"/etc/sota/conf.d/z-99-aklite-callback.toml\"
+# reboot_command = \"/bin/true\"
 sleep 5
 aktualizr-lite status --loglevel 0
+# exit with code 0 to allow result collection in case of race
+# between aklite systemd service and above call
+exit 0


### PR DESCRIPTION
Sometimes there is a race between systemd aktualizr-lite starting and
calling it from the test script. This might cause non-zero exit from the
sript and result in not registering the test result. This patch should
prevent this from happening.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>