### PR TITLE
automated: linux: fix output of lsblk in fs-resize

### DIFF
--- a/automated/linux/fs-resize/fs-resize.sh
+++ b/automated/linux/fs-resize/fs-resize.sh
@@ -52,7 +52,7 @@ INODES=$(df --output=itotal,size,target | grep "$MOUNTPOINT" | xargs echo -n | c
 echo "Inodes: $INODES"
 BLOCKS=$(df --output=itotal,size,target | grep "$MOUNTPOINT" | xargs echo -n | cut -d " " -f 2)
 echo "1k Blocks: $BLOCKS"
-DISK_SIZE=$(lsblk -b | grep "$MOUNTPOINT" | xargs echo -n | cut -d " " -f 4)
+DISK_SIZE=$(lsblk -b -o SIZE,MOUNTPOINT | grep "$MOUNTPOINT" | xargs echo -n | cut -d " " -f 1)
 echo "Disk Size (bytes): $DISK_SIZE"
 # Subtract inode table and fs size from disk size. Result should be withing 1%
 


### PR DESCRIPTION
When more than one mountpoint is attached to the block device lsblk may
print all of them. In such case the test fails as it's missing columns
in the output. This patch makes sure that only primary mountpoint is
used in lsblk output. It also removes all other columns except for the
SIZE and MOUNTPOINT. This will make the test more resilient to creative
filesystem layouts.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>