### PR TITLE
OTA rollback debug

### DIFF
--- a/automated/linux/ota-rollback/sh-lib
+++ b/automated/linux/ota-rollback/sh-lib
@@ -21,6 +21,10 @@ compare_test_value() {
     # shellcheck disable=SC2039
     local tested_value="$3"
 
+    echo "Testing: #${test_name}#"
+    echo "Expected: #${expected_value}#"
+    echo "Actual: #${tested_value}#"
+
     if [ "${expected_value}" = "${tested_value}" ]; then
         report_pass "${test_name}"
     else

--- a/automated/linux/ota-rollback/verify-reboot.sh
+++ b/automated/linux/ota-rollback/verify-reboot.sh
@@ -64,19 +64,25 @@ compare_test_value "bootcount_after_reboot" "${ref_bootcount_after_reboot}" "${b
 rollback_after_reboot=$(uboot_variable_value rollback)
 echo "Rollback: ${rollback_after_reboot}"
 compare_test_value "rollback_after_reboot" "${ref_rollback_after_reboot}" "${rollback_after_reboot}"
-bootupgrade_available_after_reboot=$(uboot_variable_value bootupgrade_available)
-compare_test_value "bootupgrade_available_after_reboot" "${ref_bootupgrade_available_after_reboot}" "${bootupgrade_available_after_reboot}"
 upgrade_available_after_reboot=$(uboot_variable_value upgrade_available)
 compare_test_value "upgrade_available_after_reboot" "${ref_upgrade_available_after_reboot}" "${upgrade_available_after_reboot}"
+if [ -f /usr/lib/firmware/version.txt ]; then
+    . /usr/lib/firmware/version.txt
+    bootupgrade_available_after_reboot=$(uboot_variable_value bootupgrade_available)
+    compare_test_value "bootupgrade_available_after_reboot" "${ref_bootupgrade_available_after_reboot}" "${bootupgrade_available_after_reboot}"
 
-. /usr/lib/firmware/version.txt
-# shellcheck disable=SC2154
-ref_bootfirmware_version_after_reboot="${bootfirmware_version}"
-if [ "${TYPE}" = "uboot" ]; then
-    ref_bootfirmware_version_after_reboot=0
+    # shellcheck disable=SC2154
+    ref_bootfirmware_version_after_reboot="${bootfirmware_version}"
+    if [ "${TYPE}" = "uboot" ]; then
+        ref_bootfirmware_version_after_reboot=0
+    fi
+    bootfirmware_version_after_reboot=$(uboot_variable_value bootfirmware_version)
+    # shellcheck disable=SC2154
+    compare_test_value "bootfirmware_version_after_reboot" "${ref_bootfirmware_version_after_reboot}" "${bootfirmware_version_after_reboot}"
+    fiovb_is_secondary_boot_after_reboot=$(uboot_variable_value fiovb.is_secondary_boot)
+    compare_test_value "fiovb_is_secondary_boot_after_reboot" "${ref_fiovb_is_secondary_boot_after_reboot}" "${fiovb_is_secondary_boot_after_reboot}"
+else
+    report_skip "bootupgrade_available_after_reboot"
+    report_skip "bootfirmware_version_after_reboot"
+    report_skip "fiovb_is_secondary_boot_after_reboot"
 fi
-bootfirmware_version_after_reboot=$(uboot_variable_value bootfirmware_version)
-# shellcheck disable=SC2154
-compare_test_value "bootfirmware_version_after_reboot" "${ref_bootfirmware_version_after_reboot}" "${bootfirmware_version_after_reboot}"
-fiovb_is_secondary_boot_after_reboot=$(uboot_variable_value fiovb.is_secondary_boot)
-compare_test_value "fiovb_is_secondary_boot_after_reboot" "${ref_fiovb_is_secondary_boot_after_reboot}" "${fiovb_is_secondary_boot_after_reboot}"

--- a/automated/linux/ota-rollback/verify-rollback.sh
+++ b/automated/linux/ota-rollback/verify-rollback.sh
@@ -58,23 +58,28 @@ bootcount_after_rollback=$(uboot_variable_value bootcount)
 compare_test_value "bootcount_after_rollback" "${ref_bootcount_after_rollback}" "${bootcount_after_rollback}"
 rollback_after_rollback=$(uboot_variable_value rollback)
 compare_test_value "rollback_after_rollback" "${ref_rollback_after_rollback}" "${rollback_after_rollback}"
-bootupgrade_available_after_rollback=$(uboot_variable_value bootupgrade_available)
-compare_test_value "bootupgrade_available_after_rollback" "${ref_bootupgrade_available_after_rollback}" "${bootupgrade_available_after_rollback}"
 upgrade_available_after_rollback=$(uboot_variable_value upgrade_available)
 compare_test_value "upgrade_available_after_rollback" "${ref_upgrade_available_after_rollback}" "${upgrade_available_after_rollback}"
+if [ -f /usr/lib/firmware/version.txt ]; then
+    . /usr/lib/firmware/version.txt
+    bootupgrade_available_after_rollback=$(uboot_variable_value bootupgrade_available)
+    compare_test_value "bootupgrade_available_after_rollback" "${ref_bootupgrade_available_after_rollback}" "${bootupgrade_available_after_rollback}"
 
-. /usr/lib/firmware/version.txt
-# shellcheck disable=SC2154
-ref_bootfirmware_version_after_rollback="${bootfirmware_version}"
-if [ "${TYPE}" = "uboot" ]; then
-    ref_bootfirmware_version_after_rollback=0
+    # shellcheck disable=SC2154
+    ref_bootfirmware_version_after_rollback="${bootfirmware_version}"
+    if [ "${TYPE}" = "uboot" ]; then
+        ref_bootfirmware_version_after_rollback=0
+    fi
+    bootfirmware_version_after_rollback=$(uboot_variable_value bootfirmware_version)
+    # shellcheck disable=SC2154
+    compare_test_value "bootfirmware_version_after_rollback" "${ref_bootfirmware_version_after_rollback}" "${bootfirmware_version_after_rollback}"
+    fiovb_is_secondary_boot_after_rollback=$(uboot_variable_value fiovb.is_secondary_boot)
+    compare_test_value "fiovb_is_secondary_boot_after_rollback" "${ref_fiovb_is_secondary_boot_after_rollback}" "${fiovb_is_secondary_boot_after_rollback}"
+else
+    report_skip "bootupgrade_available_after_rollback"
+    report_skip "bootfirmware_version_after_rollback"
+    report_skip "fiovb_is_secondary_boot_after_rollback"
 fi
-bootfirmware_version_after_rollback=$(uboot_variable_value bootfirmware_version)
-# shellcheck disable=SC2154
-compare_test_value "bootfirmware_version_after_rollback" "${ref_bootfirmware_version_after_rollback}" "${bootfirmware_version_after_rollback}"
-fiovb_is_secondary_boot_after_rollback=$(uboot_variable_value fiovb.is_secondary_boot)
-compare_test_value "fiovb_is_secondary_boot_after_rollback" "${ref_fiovb_is_secondary_boot_after_rollback}" "${fiovb_is_secondary_boot_after_rollback}"
-
 # for now ignore /etc/os-release
 cat /etc/os-release
 cat /boot/loader/uEnv.txt


### PR DESCRIPTION
OTA rollback test had issues with devices that use RPMB instead of u-boot environment.  Some variables are only set by aktualizr-lite when is starts. This patch fixes the problem.