### PR TITLE
lib: sh-test-lib: update detect_abi combinations

### DIFF
--- a/automated/lib/sh-test-lib
+++ b/automated/lib/sh-test-lib
@@ -202,9 +202,13 @@ add_metric() {
 detect_abi() {
     abi=$(uname -m)
     case "${abi}" in
-      armv7|armv7l|armv7el|armv7lh) abi="armeabi" ;;
-      arm64|armv8|arm64-v8a|aarch64) abi="arm64" ;;
-      i386|i686) abi="i386" ;;
+      armv8l) abi="armeabi" ;;
+      armv*l) abi="armeabi" ;;
+      #armv8b) abi="armeabibe" ;;
+      #armv*b) abi="armeabibe" ;;
+      aarch64) abi="arm64" ;;
+      #aarch64_be) abi="arm64be" ;;
+      i*86) abi="i386" ;;
       x86_64) abi="x86_64" ;;
       *) error_msg "Unsupported architecture: ${abi}" ;;
     esac


### PR DESCRIPTION
Update the combinations that linux can report back via 'uname -m'.
This makes use able to run:
- "armv{4,4t,5t,5te,5tej,6,7,7m}l" for little-endian arm32 kernels
- "armv{4,4t,5t,5te,5tej}b for big-endian arm32 (be32) kernels
- "armv{6,7,7m}b" for big-endian arm32 (be8) kernels
- "armv8l" for little-endian arm64 kernels in 32-bit mode
- "armv8b" for big-endian arm64 kernels in 32-bit mode
- "aarch64" for little-endian arm64 kernels in 64-bit mode
- "aarch64_be" for big-endian arm64 kernels in 64-bit mode

For now the bigendian flavors are there but commented out for completeness.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>