### PR TITLE
automated: linux: fix ota-rollback timing issue

### DIFF
--- a/automated/linux/ota-rollback/download-update.sh
+++ b/automated/linux/ota-rollback/download-update.sh
@@ -87,6 +87,8 @@ while ! systemctl is-active aktualizr-lite; do
     echo "Waiting for aktualizr-lite to start"
     sleep 1
 done
+# add some delay so aklite can setup variables
+sleep 5
 
 # u-boot variables change when aklite starts (at least on some devices)
 # check u-boot variables to ensure we're on freshly flashed device


### PR DESCRIPTION
When aktualizr-lite starts it takes a few seconds before it sets proper
u-boot variables. Before this patch the variables were read before
aklite had chance to set their values.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>