### PR TITLE
spectre-meltdown-checker: Add execution by /bin/sh

### DIFF
--- a/automated/linux/spectre-meltdown-checker-test/spectre-meltdown-checker-test.sh
+++ b/automated/linux/spectre-meltdown-checker-test/spectre-meltdown-checker-test.sh
@@ -43,7 +43,7 @@ parse_smc_output() {
 }
 
 smc_run() {
-    ./spectre-meltdown-checker.sh  --no-color --batch | tee "${OUTPUT}/${LOG_FILE}.log"
+    sh ./spectre-meltdown-checker.sh  --no-color --batch | tee "${OUTPUT}/${LOG_FILE}.log"
     parse_smc_output "${OUTPUT}/${LOG_FILE}.log"
 }
 


### PR DESCRIPTION
Since spectre-meltdown-checker.sh does not have execute permission,
so an error will occur when executing.

```
+ cd ./automated/linux/spectre-meltdown-checker-test
+ ./spectre-meltdown-checker-test.sh -s False -v v0.45 -w False
./spectre-meltdown-checker-test.sh: 46:
./spectre-meltdown-checker-test.sh: ./spectre-meltdown-checker.sh:
Permission denied
+ ../../utils/send-to-lava.sh ./output/result.txt
```

There are several ways to work around this issue, but I can do so by
running it with /bin/sh at run time.

Signed-off-by: Nobuhiro Iwamatsu <nobuhiro1.iwamatsu@toshiba.co.jp>