### PR TITLE
Tensorflow MLPerf tests for D05

### DIFF
--- a/automated/linux/tensorflow/imagenet-resnet50.sh
+++ b/automated/linux/tensorflow/imagenet-resnet50.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+source ./tensorflow-utils.sh
+
+HOME_DIR='/home/debiand05'
+TEST_GIT_URL="https://github.com/mlcommons/inference.git"
+TEST_DIR="${HOME_DIR}/src/${TEST_PROGRAM}"
+TEST_PROG_VERSION="215c057fc6690a47f3f66c72c076a8f73d66cb12"
+TEST_PROGRAM="inference"
+MNT_DIR='/mnt'
+MNT_EXISTS=true
+
+usage() {
+    echo "Usage: $0 [-a <home-directory>]
+                    [-m <mount-directory>]
+                    [-t <true|false>]
+                    [-p <test-dir>]
+                    [-v <test-prog-version>]
+                    [-u <test-git-url>]
+                    [-s <true|false>]" 1>&2
+    exit 1
+}
+
+while getopts "a:m:t:s:p:v:u:" o; do
+    case "$o" in
+        a) export HOME_DIR="${OPTARG}";;
+        m) MNT_DIR="${OPTARG}" ;;
+        t) MNT_EXISTS="${OPTARG}" ;;
+        s) SKIP_INSTALL="${OPTARG}" ;;
+        p) export TEST_DIR="${OPTARG}" ;;
+        v) export TEST_PROG_VERSION="${OPTARG}" ;;
+        u) export TEST_GIT_URL="${OPTARG}" ;;
+        *) usage ;;
+    esac
+done
+
+pkgs="build-essential git python3-venv python3-dev libhdf5-dev pkg-config curl"
+install_deps "${pkgs}" "${SKIP_INSTALL}"
+create_out_dir "${OUTPUT}"
+rm -rf "${HOME_DIR}"/tf_venv
+rm -rf "${HOME_DIR}"/src
+rm -rf "${MNT_DIR}"/datasets
+mkdir "${HOME_DIR}"/tf_venv
+pushd "${HOME_DIR}"/tf_venv || exit
+python3 -m venv .
+source bin/activate
+popd || exit
+
+if [[ "${SKIP_INSTALL}" = *alse ]]; then
+    tensorflow_pip_install
+    if [[ "${MNT_EXISTS}" = *alse ]]; then
+        get_dataset_imagenet_resnet50
+    fi
+fi
+
+pushd "${HOME_DIR}"/src/inference/vision/classification_and_detection/ || exit
+python setup.py develop
+
+if [[ "${MNT_EXISTS}" = *rue ]]; then
+    mkdir "${MNT_DIR}"/datasets
+    mount -t nfs 10.40.96.10:/mnt/nvme "${MNT_DIR}"/datasets
+    export DATA_DIR="${MNT_DIR}"/datasets/data/CK-TOOLS/dataset-imagenet-ilsvrc2012-val-min
+    export MODEL_DIR="${MNT_DIR}"/datasets/data/models
+fi
+
+./run_local.sh tf resnet50
+popd || exit

--- a/automated/linux/tensorflow/imagenet-resnet50.yaml
+++ b/automated/linux/tensorflow/imagenet-resnet50.yaml
@@ -1,0 +1,24 @@
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: imagenet-resnet50
+    description: "imagenet-resnet50 job, running resnet50 benchmark through mlperf."
+    maintainer:
+        - theodore.grey@linaro.org
+    os:
+        - debian
+    scope:
+        - functional
+    devices:
+        - hip07-d05
+params:
+    HOME_DIR: '/home/debiand05'
+    MNT_DIR: '/mnt'
+    MNT_EXISTS: true
+    SKIP_INSTALL: false
+    TEST_PROG_VERSION: "215c057fc6690a47f3f66c72c076a8f73d66cb12"
+    TEST_GIT_URL: "https://github.com/mlcommons/inference.git"
+    TEST_DIR: "${HOME_DIR}/src/${TEST_PROGRAM}"
+run:
+    steps:
+        - cd ./automated/linux/tensorflow/
+        - ./imagenet-resnet50.sh -s "${SKIP_INSTALL}" -a "${HOME_DIR}" -m "${MNT_DIR}" -t "${MNT_EXISTS}" -v "${TEST_PROG_VERSION}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}"

--- a/automated/linux/tensorflow/imagenet-ssd-resnet34.sh
+++ b/automated/linux/tensorflow/imagenet-ssd-resnet34.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+source ./tensorflow-utils.sh
+
+HOME_DIR='/home/debiand05'
+TEST_GIT_URL="https://github.com/mlcommons/inference.git"
+TEST_DIR="${HOME_DIR}/src/${TEST_PROGRAM}"
+TEST_PROG_VERSION="215c057fc6690a47f3f66c72c076a8f73d66cb12"
+TEST_PROGRAM="inference"
+MNT_DIR='/mnt'
+MNT_EXISTS=true
+
+usage() {
+    echo "Usage: $0 [-a <home-directory>]
+                    [-m <mount-directory>]
+                    [-t <true|false>]
+                    [-p <test-dir>]
+                    [-v <test-prog-version>]
+                    [-u <test-git-url>]
+                    [-s <true|false>]" 1>&2
+    exit 1
+}
+
+while getopts "a:m:t:s:p:v:u:" o; do
+    case "$o" in
+        a) export HOME_DIR="${OPTARG}";;
+        m) MNT_DIR="${OPTARG}" ;;
+        t) MNT_EXISTS="${OPTARG}" ;;
+        s) SKIP_INSTALL="${OPTARG}" ;;
+        p) export TEST_DIR="${OPTARG}" ;;
+        v) export TEST_PROG_VERSION="${OPTARG}" ;;
+        u) export TEST_GIT_URL="${OPTARG}" ;;
+        *) usage ;;
+    esac
+done
+
+pkgs="build-essential git python3-venv python3-dev libhdf5-dev pkg-config curl"
+install_deps "${pkgs}" "${SKIP_INSTALL}"
+create_out_dir "${OUTPUT}"
+rm -rf "${HOME_DIR}"/tf_venv
+rm -rf "${HOME_DIR}"/src
+rm -rf "${MNT_DIR}"/datasets
+mkdir "${HOME_DIR}"/tf_venv
+pushd "${HOME_DIR}"/tf_venv || exit
+python3 -m venv .
+source bin/activate
+popd || exit
+
+if [[ "${SKIP_INSTALL}" = *alse ]]; then
+    export CFLAGS="-std=c++14 -Wp,-U_GLIBCXX_ASSERTATIONS"
+    tensorflow_pip_install
+    unset CFLAGS
+    if [[ "${MNT_EXISTS}" = *alse ]]; then
+        get_dataset_imagenet_ssd_resnet34
+    fi
+fi
+
+pushd "${HOME_DIR}"/src/inference/vision/classification_and_detection/ || exit
+python setup.py develop
+
+if [[ "${MNT_EXISTS}" = *rue ]]; then
+    mkdir "${MNT_DIR}"/datasets
+    mount -t nfs 10.40.96.10:/mnt/nvme "${MNT_DIR}"/datasets
+    export DATA_DIR="${MNT_DIR}"/datasets/data/CK-TOOLS/dataset-coco-2017-val
+    export MODEL_DIR="${MNT_DIR}"/datasets/data/models
+fi
+
+./run_local.sh tf ssd-resnet34 --data-format NHWC
+popd || exit

--- a/automated/linux/tensorflow/imagenet-ssd-resnet34.yaml
+++ b/automated/linux/tensorflow/imagenet-ssd-resnet34.yaml
@@ -1,0 +1,24 @@
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: imagenet-ssd-resnet32
+    description: "imagenet-ssd-resnet32 job, running resnet32 benchmark through mlperf."
+    maintainer:
+        - theodore.grey@linaro.org
+    os:
+        - debian
+    scope:
+        - functional
+    devices:
+        - hip07-d05
+params:
+    HOME_DIR: '/home/debiand05'
+    MNT_DIR: '/mnt'
+    MNT_EXISTS: true
+    SKIP_INSTALL: false
+    TEST_PROG_VERSION: "215c057fc6690a47f3f66c72c076a8f73d66cb12"
+    TEST_GIT_URL: "https://github.com/mlcommons/inference.git"
+    TEST_DIR: "${HOME_DIR}/src/${TEST_PROGRAM}"
+run:
+    steps:
+        - cd ./automated/linux/tensorflow/
+        - ./imagenet-ssd-resnet32.sh -s "${SKIP_INSTALL}" -a "${HOME_DIR}" -m "${MNT_DIR}" -t "${MNT_EXISTS}" -v "${TEST_PROG_VERSION}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}"

--- a/automated/linux/tensorflow/ssd-mobilenet.sh
+++ b/automated/linux/tensorflow/ssd-mobilenet.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+source ./tensorflow-utils.sh
+
+HOME_DIR='/home/debiand05'
+TEST_GIT_URL="https://github.com/mlcommons/inference.git"
+TEST_DIR="${HOME_DIR}/${TEST_PROGRAM}"
+TEST_PROG_VERSION="215c057fc6690a47f3f66c72c076a8f73d66cb12"
+TEST_PROGRAM="inference"
+MNT_DIR='/mnt'
+MNT_EXISTS=true
+
+usage() {
+    echo "Usage: $0 [-a <home-directory>]
+                    [-m <mount-directory>]
+                    [-t <true|false>]
+                    [-p <test-dir>]
+                    [-v <test-prog-version>]
+                    [-u <test-git-url>]
+                    [-s <true|false>]" 1>&2
+    exit 1
+}
+
+while getopts "a:m:t:s:p:v:u:" o; do
+    case "$o" in
+        a) export HOME_DIR="${OPTARG}";;
+        m) MNT_DIR="${OPTARG}" ;;
+        t) MNT_EXISTS="${OPTARG}" ;;
+        s) SKIP_INSTALL="${OPTARG}" ;;
+        p) export TEST_DIR="${OPTARG}" ;;
+        v) export TEST_PROG_VERSION="${OPTARG}" ;;
+        u) export TEST_GIT_URL="${OPTARG}" ;;
+        *) usage ;;
+    esac
+done
+
+pkgs="build-essential git python3-venv python3-dev libhdf5-dev pkg-config curl"
+install_deps "${pkgs}" "${SKIP_INSTALL}"
+create_out_dir "${OUTPUT}"
+rm -rf "${HOME_DIR}"/tf_venv
+rm -rf "${HOME_DIR}"/src
+rm -rf "${MNT_DIR}"/datasets
+mkdir "${HOME_DIR}"/tf_venv
+pushd "${HOME_DIR}"/tf_venv || exit
+python3 -m venv .
+source bin/activate
+popd || exit
+
+if [[ "${SKIP_INSTALL}" = *alse ]]; then
+    export CFLAGS="-std=c++14 -Wp,-U_GLIBCXX_ASSERTIONS"
+    tensorflow_pip_install
+    unset CFLAGS
+    if [[ "${MNT_EXISTS}" = *alse ]]; then
+        get_dataset_ssd_mobilenet
+    fi
+fi
+
+pushd "${HOME_DIR}"/src/inference/vision/classification_and_detection || exit
+python setup.py develop
+
+if [[ "${MNT_EXISTS}" = *rue ]]; then
+    mkdir "${MNT_DIR}"/datasets
+    mount -t nfs 10.40.96.10:/mnt/nvme "${MNT_DIR}"/datasets
+    export DATA_DIR="${MNT_DIR}"/datasets/data/CK-TOOLS/dataset-coco-2017-val
+    export MODEL_DIR="${MNT_DIR}"/datasets/data/models
+fi
+
+./run_local.sh tf ssd-mobilenet
+popd || exit

--- a/automated/linux/tensorflow/ssd-mobilenet.yaml
+++ b/automated/linux/tensorflow/ssd-mobilenet.yaml
@@ -1,0 +1,24 @@
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: ssd-mobilenet
+    description: "ssd-mobilenet job, running ssd-mobilenet benchmark through mlperf."
+    maintainer:
+        - theodore.grey@linaro.org
+    os:
+        - debian
+    scope:
+        - functional
+    devices:
+        - hip07-d05
+params:
+    HOME_DIR: '/home/debiand05'
+    MNT_DIR: '/mnt'
+    MNT_EXISTS: true
+    SKIP_INSTALL: false
+    TEST_PROG_VERSION: "215c057fc6690a47f3f66c72c076a8f73d66cb12"
+    TEST_GIT_URL: "https://github.com/mlcommons/inference.git"
+    TEST_DIR: "${HOME_DIR}/src/${TEST_PROGRAM}"
+run:
+    steps:
+        - cd ./automated/linux/tensorflow/
+        - ./ssd-mobilenet.sh -s "${SKIP_INSTALL}" -a "${HOME_DIR}" -m "${MNT_DIR}" -t "${MNT_EXISTS}" -v "${TEST_PROG_VERSION}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}"

--- a/automated/linux/tensorflow/tensorflow-utils.sh
+++ b/automated/linux/tensorflow/tensorflow-utils.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+export DATA_DIR=${HOME}/CK-TOOLS/dataset-coco-2017-val
+export MODEL_DIR=${HOME}/models
+
+#PIP install prerequisits required for running tensorflow via ck and MLPerf.
+tensorflow_pip_install(){
+    pushd "${HOME_DIR}"/tf_venv || exit
+    python -m pip install --upgrade pip wheel
+    python -m pip install h5py
+    python -m pip install cython
+    python -m pip install google protobuf==3.20.1
+    python -m pip install --no-binary pycocotools pycocotools
+    python -m pip install absl-py pillow
+    python -m pip install --extra-index-url https://snapshots.linaro.org/ldcg/python-cache/ numpy==1.19.5
+    python -m pip install --extra-index-url https://snapshots.linaro.org/ldcg/python-cache/ matplotlib
+    python -m pip install ck
+    ck pull repo:ck-env
+    python -m pip install scikit-build
+    python -m pip install --extra-index-url https://snapshots.linaro.org/ldcg/python-cache/ tensorflow-io-gcs-filesystem==0.24.0 h5py==3.1.0
+    python -m pip install tensorflow-aarch64==2.7.0
+    popd || exit
+    mkdir "${HOME_DIR}"/src
+    get_test_program "${TEST_GIT_URL}" "${TEST_DIR}" "${TEST_PROG_VERSION}" "${TEST_PROGRAM}"
+    git submodule update --init --recursive
+    pushd "${HOME_DIR}"/src/"${TEST_PROGRAM}"/loadgen || exit
+    python setup.py develop
+    popd || exit
+}
+#Setup for the ssd_mobilenet dataset if the dataset does not already exist on device
+get_dataset_ssd_mobilenet(){
+    mkdir models
+    pushd models || exit
+    ck install package --tags=object-detection,dataset,coco,val
+    mobilenet="http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224.tgz"
+    curl -sSOL "${mobilenet}"
+    tar -zxf "$(baseame "${mobilenet}")"
+    ssd_mobilenet_coco_version="ssd_mobilenet_v1_coco_2018_01_28"
+    ssd_mobilenet="http://download.tensorflow.org/models/object_detection/${ssd_mobilenet_coco_version}.tar.gz"
+    curl -sSOL "${ssd_mobilenet}"
+    tar -zxf "$(baseame "${ssd_mobilenet}")"
+    cp "${ssd_mobilenet_coco_version}/frozen_inference_graph.pb" "${ssd_mobilenet_coco_version}.pb"
+    popd  || exit
+}
+#Setup for the imagenet-ssd-resnet32 dataset if the dataset does not already exist on device
+get_dataset_imagenet_ssd_resnet32(){
+    mkdir models
+    pushd models || exit
+    ck install package --tags=object-detection,dataset,coco,val # Choose [0] the 2017 data
+    ssd_resnet34="https://zenodo.org/record/3345892/files/tf_ssd_resnet34_22.1.zip"
+    curl -sSOL "${ssd_resnet34}"
+    unzip "$(baseame "${ssd_resnet34}")"
+    cp tf_ssd_resnet34_22.1/resnet34_tf.22.1.pb .
+    popd || exit
+    pushd "${HOME_DIR}"/src/inference/vision/classification_and_detection  || exit
+    python tools/ssd-nhwc.py ~/models/resnet34_tf.22.1.pb
+    mv ~/models/resnet34_tf.22.1.pb.patch ~/models/resnet34_tf.22.1.pb
+    popd  || exit
+}
+#Setup for the resnet50 dataset if the dataset does not already exist on device
+get_dataset_imagenet_resnet50(){
+    mkdir models
+    pushd models || exit
+    ck install package --tags=image-classification,dataset,imagenet,aux
+    ck install package --tags=image-classification,dataset,imagenet,val
+    cp "${HOME_DIR}"/CK-TOOLS/dataset-imagenet-ilsvrc2012-aux-from.dividiti/val.txt "${HOME_DIR}"/CK-TOOLS/dataset-imagenet-ilsvrc2012-val-min/val_map.txt
+    resnet50="https://zenodo.org/record/2535873/files/resnet50_v1.pb"
+    curl -sSOL "${resnet50}"
+    export DATA_DIR=${HOME}/CK-TOOLS/dataset-imagenet-ilsvrc2012-val-min
+    popd || exit
+}


### PR DESCRIPTION
Creating automation of Tensorflow MLPerf tests on the D05 : resnet50, ssd-resnet32, and ssd-mobilenet. These scripts can be run with or without mounting the device to a NFS drive with pre downloaded data sets (only available for devices in Cambridge COLO).

These scripts run a Tensorflow Benchmark with the equivalent dataset (resnet50, ssd-mobilenet etc.) and are meant to give accurate benchmark data on the Tensorflow Library.

Signed-off-by: Theodore Grey <theodore.grey@linaro.org>