### PR TITLE
Add Real-time Linux Analysis tool

### DIFF
--- a/automated/lib/parse_rt_tests_results.py
+++ b/automated/lib/parse_rt_tests_results.py
@@ -28,8 +28,12 @@ import sys
 import json
 
 
-def print_res(t, res, key):
-    print("t{}-{}-latency pass {} us".format(t, key, res[key]))
+def print_thread_res(tid, res, key):
+    print("t{}-{}-latency pass {} us".format(tid, key, res[key]))
+
+
+def print_irq_res(iid, res, key):
+    print("i{}-{}-latency pass {} us".format(iid, key, res[key]))
 
 
 def parse_threads(rawdata):
@@ -41,8 +45,17 @@ def parse_threads(rawdata):
         else:
             data = rawdata["thread"][tid]
 
-        for k in ["min", "avg", "max"]:
-            print_res(tid, data, k)
+        for key in ["min", "avg", "max"]:
+            print_thread_res(tid, data, key)
+
+
+def parse_irqs(rawdata):
+    num_irqs = int(rawdata["num_irqs"])
+    for irq_id in range(num_irqs):
+        iid = str(irq_id)
+        data = rawdata["irq"][iid]
+        for key in ["min", "avg", "max"]:
+            print_irq_res(iid, data, key)
 
 
 def parse_json(testname, filename):
@@ -52,6 +65,10 @@ def parse_json(testname, filename):
     if "num_threads" in rawdata:
         # most rt-tests have generic per thread results
         parse_threads(rawdata)
+    if "num_irqs" in rawdata:
+        # rlta timertat also knows about irqs
+        parse_irqs(rawdata)
+
     elif "inversions" in rawdata:
         # pi_stress
         print("inversion {}\n".format(rawdata("inversions")))

--- a/automated/linux/rtla/parse_rtla.py
+++ b/automated/linux/rtla/parse_rtla.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+import argparse
+import platform
+import json
+
+# Transform rtla hist out data into the same format as rt-tests
+# framework is producing.
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-r",
+        "--result-file",
+        dest="result_file",
+        required=True,
+        default="./result.txt",
+        help="Specify test result file.",
+    )
+    parser.add_argument(
+        "-t",
+        "--test-name",
+        required=True,
+        help="Specify test name.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        dest="output",
+        help="Specify output file.",
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def get_sysinfo():
+    sysinfo = {}
+
+    uname = platform.uname()
+    sysinfo["sysname"] = uname.system
+    sysinfo["nodename"] = uname.node
+    sysinfo["release"] = uname.release
+    sysinfo["version"] = uname.version
+    sysinfo["machine"] = uname.machine
+
+    realtime = 0
+    try:
+        with open("/sys/kernel/realtime", "r") as rfl:
+            realtime = int(rfl.read(1))
+    except IOError:
+        pass
+    sysinfo["realtime"] = realtime
+
+    return sysinfo
+
+
+def parse_histogram(col, sel, i, hist):
+    if i not in hist:
+        hist[i] = {}
+        hist[i]["histogram"] = {}
+
+    if col[0].endswith(":"):
+        name = col[0][:-1]
+        hist[i][name] = int(col[sel])
+    else:
+        hist[i]["histogram"][col[0]] = int(col[sel])
+
+
+def parse_osnoise(result_file):
+    data = {}
+    threads = {}
+    for line in result_file.readlines():
+        if line.startswith(" "):
+            continue
+
+        col = line.split()
+
+        num_cols = len(col) - 1
+
+        for i, sel in zip(range(0, num_cols), range(1, len(col), 1)):
+            parse_histogram(col, sel, i, threads)
+
+    data["file_version"] = 2
+    data["return_code"] = 0
+    data["sysinfo"] = get_sysinfo()
+    data["num_threads"] = num_cols
+    data["resolution_in_ns"] = 0
+    data["thread"] = threads
+
+    return data
+
+
+def main(args):
+    with open(args.result_file, "r") as infile:
+        if args.test_name == "osnoise":
+            data = parse_osnoise(infile)
+
+    if args.output:
+        with open(args.output, "w") as outfile:
+            outfile.write(json.dumps(data, indent=2))
+    else:
+        print(json.dumps(data, indent=2))
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/automated/linux/rtla/parse_rtla.py
+++ b/automated/linux/rtla/parse_rtla.py
@@ -91,10 +91,42 @@ def parse_osnoise(result_file):
     return data
 
 
+def parse_timerlat(result_file):
+    data = {}
+    threads = {}
+    irqs = {}
+    num_cols = 0
+    for line in result_file.readlines():
+        if line.startswith(" "):
+            continue
+
+        col = line.split()
+
+        num_cols = len(col) - 1
+
+        for i, sel in zip(range(0, num_cols), range(1, len(col), 2)):
+            parse_histogram(col, sel, i, irqs)
+        for i, sel in zip(range(0, num_cols), range(2, len(col), 2)):
+            parse_histogram(col, sel, i, threads)
+
+    data["file_version"] = 2
+    data["return_code"] = 0
+    data["sysinfo"] = get_sysinfo()
+    data["num_threads"] = num_cols / 2
+    data["num_irqs"] = num_cols / 2
+    data["resolution_in_ns"] = 0
+    data["thread"] = threads
+    data["irq"] = irqs
+
+    return data
+
+
 def main(args):
     with open(args.result_file, "r") as infile:
         if args.test_name == "osnoise":
             data = parse_osnoise(infile)
+        else:
+            data = parse_timerlat(infile)
 
     if args.output:
         with open(args.output, "w") as outfile:

--- a/automated/linux/rtla/rtla-osnoise.sh
+++ b/automated/linux/rtla/rtla-osnoise.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# RTLA provides a set of tools for the analysis of the kernel’s
+# realtime behavior on specific hardware.
+
+# shellcheck disable=SC1091
+. ../../lib/sh-test-lib
+
+OUTPUT="$(pwd)/output"
+TMPFILE="${OUTPUT}/rtla-osnoise.txt"
+LOGFILE="${OUTPUT}/rtla-osnoise.json"
+RESULT_FILE="${OUTPUT}/result.txt"
+
+DURATION="1m"
+BACKGROUND_CMD=""
+
+usage() {
+    echo "Usage: $0 [-d duration ] [-w background_cmd]" 1>&2
+    exit 1
+}
+
+while getopts ":d:w:" opt; do
+    case "${opt}" in
+        d) DURATION="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
+        *) usage ;;
+    esac
+done
+
+! check_root && error_msg "Please run this script as root."
+create_out_dir "${OUTPUT}"
+
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
+# real-time priority FIFO:1, on all CPUs, for 900ms at each period (1s by default)
+rtla osnoise hist -P F:1 -r 900000 -d "${DURATION}" --no-header --trace \
+     -e osnoise:irq_noise \
+     --trigger hist:key=cpu,desc,duration.buckets=1000:sort=duration \
+     -e osnoise:thread_noise \
+     --trigger hist:key=cpu,comm,duration.buckets=1000:sort=duration \
+     -e osnoise:sample_threshold \
+     --trigger 'hist:key=cpu,duration.buckets=1000:sort=duration if interference == 0' \
+    | tee -a "${TMPFILE}"
+
+background_process_stop bgcmd
+
+mv osnoise_thread_noise_hist.txt "${OUTPUT}"
+mv osnoise_irq_noise_hist.txt "${OUTPUT}"
+mv osnoise_sample_threshold_hist.txt "${OUTPUT}"
+# Parse test log.
+./parse_rtla.py -t osnoise -r "${TMPFILE}" -o "${LOGFILE}"
+../../lib/parse_rt_tests_results.py rtla-osnoise "${LOGFILE}" \
+    | tee -a "${RESULT_FILE}"

--- a/automated/linux/rtla/rtla-osnoise.yaml
+++ b/automated/linux/rtla/rtla-osnoise.yaml
@@ -1,0 +1,55 @@
+metadata:
+    name: rtla-osnoise
+    format: "Lava-Test Test Definition 1.0"
+    description: "The rtla osnoise tool is an interface for the osnoise tracer.
+                  The osnoise tracer dispatches a kernel thread per-cpu.
+                  These threads read the time in a loop while with preemption,
+                  softirq and IRQs enabled, thus allowing all the sources of
+                  operating system noise during its execution. The osnoise’s
+                  tracer threads take note of the delta between each time
+                  read, along with an interference counter of all sources of
+                  interference. At the end of each period, the osnoise tracer
+                  displays a summary of the results."
+    maintainer:
+        - Daniel Wagner <wagi@monom.org>
+    os:
+        - debian
+        - ubuntu
+        - fedora
+        - centos
+        - openembedded
+    scope:
+        - performance
+        - preempt-rt
+    environment:
+        - lava-test-shell
+    devices:
+        - hi6220-hikey
+        - apq8016-sbc
+        - mustang
+        - moonshot
+        - thunderX
+        - d03
+        - d05
+
+params:
+    # Execute rtla osnoise for given time
+    DURATION: "5m"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
+    # Specify url and token for publishing artifacts.
+    # For safety reasons, please set 'ARTIFACTORIAL_TOKEN' variable in job definition with
+    # 'secrets' dictionary, and set job visibility to personal or group.
+    # Refer to https://validation.linaro.org/static/docs/v2/publishing-artifacts.html
+    ARTIFACTORIAL_URL: "https://archive.validation.linaro.org/artifacts/team/qa/"
+    ARTIFACTORIAL_TOKEN: ""
+
+run:
+    steps:
+        - cd ./automated/linux/rtla/
+        - ./rtla-osnoise.sh -d "${DURATION}" -w "${BACKGROUND_CMD}"
+        - ../../utils/upload-to-artifactorial.sh -a "output/rtla-osnoise.json" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"
+        - ../../utils/upload-to-artifactorial.sh -a "output/osnoise_thread_noise_hist.txt" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"
+        - ../../utils/upload-to-artifactorial.sh -a "output/osnoise_irq_noise_hist.txt" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"
+        - ../../utils/upload-to-artifactorial.sh -a "output/osnoise_sample_threshold_hist.txt" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"
+        - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/rtla/rtla-timerlat.sh
+++ b/automated/linux/rtla/rtla-timerlat.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# RTLA provides a set of tools for the analysis of the kernel’s
+# realtime behavior on specific hardware.
+
+# shellcheck disable=SC1091
+. ../../lib/sh-test-lib
+
+OUTPUT="$(pwd)/output"
+TMPFILE="${OUTPUT}/rtla-timerlat.txt"
+LOGFILE="${OUTPUT}/rtla-timerlat.json"
+RESULT_FILE="${OUTPUT}/result.txt"
+
+DURATION="1m"
+BACKGROUND_CMD=""
+
+usage() {
+    echo "Usage: $0 [-d duration ] [-w background_cmd]" 1>&2
+    exit 1
+}
+
+while getopts ":d:w:" opt; do
+    case "${opt}" in
+        d) DURATION="${OPTARG}" ;;
+	w) BACKGROUND_CMD="${OPTARG}" ;;
+        *) usage ;;
+    esac
+done
+
+! check_root && error_msg "Please run this script as root."
+create_out_dir "${OUTPUT}"
+
+background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
+
+rtla timerlat hist --dma-latency=0 -d "${DURATION}" --no-header --trace \
+     -e osnoise:irq_noise \
+     --trigger hist:key=cpu,desc,duration.buckets=1000:sort=duration \
+     -e osnoise:thread_noise \
+     --trigger hist:key=cpu,comm,duration.buckets=1000:sort=duration \
+    | tee -a "${TMPFILE}"
+
+background_process_stop bgcmd
+
+mv osnoise_thread_noise_hist.txt "${OUTPUT}"
+mv osnoise_irq_noise_hist.txt "${OUTPUT}"
+# Parse test log.
+./parse_rtla.py -t timerlat -r "${TMPFILE}" -o "${LOGFILE}"
+../../lib/parse_rt_tests_results.py rtla-timerlat "${LOGFILE}" \
+    | tee -a "${RESULT_FILE}"

--- a/automated/linux/rtla/rtla-timerlat.yaml
+++ b/automated/linux/rtla/rtla-timerlat.yaml
@@ -1,0 +1,51 @@
+metadata:
+    name: rtla-timerlat
+    format: "Lava-Test Test Definition 1.0"
+    description: "The rtla timerlat tool is an interface for the timerlat
+                  tracer. The timerlat tracer dispatches a kernel thread per-cpu.
+                  These threads set a periodic timer to wake themselves up and
+                  go back to sleep. After the wakeup, they collect and generate
+                  useful information for the debugging of operating system
+                  timer latency."
+    maintainer:
+        - Daniel Wagner <wagi@monom.org>
+    os:
+        - debian
+        - ubuntu
+        - fedora
+        - centos
+        - openembedded
+    scope:
+        - performance
+        - preempt-rt
+    environment:
+        - lava-test-shell
+    devices:
+        - hi6220-hikey
+        - apq8016-sbc
+        - mustang
+        - moonshot
+        - thunderX
+        - d03
+        - d05
+
+params:
+    # Execute rtla timerlat for given time
+    DURATION: "5m"
+    # Background workload to be run during the meassurement
+    BACKGROUND_CMD: ""
+    # Specify url and token for publishing artifacts.
+    # For safety reasons, please set 'ARTIFACTORIAL_TOKEN' variable in job definition with
+    # 'secrets' dictionary, and set job visibility to personal or group.
+    # Refer to https://validation.linaro.org/static/docs/v2/publishing-artifacts.html
+    ARTIFACTORIAL_URL: "https://archive.validation.linaro.org/artifacts/team/qa/"
+    ARTIFACTORIAL_TOKEN: ""
+
+run:
+    steps:
+        - cd ./automated/linux/rtla/
+        - ./rtla-timerlat.sh -d "${DURATION}" -w "${BACKGROUND_CMD}"
+        - ../../utils/upload-to-artifactorial.sh -a "output/rtla-timerlat.json" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"
+        - ../../utils/upload-to-artifactorial.sh -a "output/osnoise_thread_noise_hist.txt" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"
+        - ../../utils/upload-to-artifactorial.sh -a "output/osnoise_irq_noise_hist.txt" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
The rtla is a meta-tool that includes a set of commands that aims to analyze the real-time properties of Linux. But instead of testing Linux as a black box, rtla leverages kernel tracing capabilities to provide precise information about the properties and root causes of unexpected results.

- osnoise
  Gives information about the operating system noise (osnoise).

- timerlat
  Measures the IRQ and thread timer latency.

See for more information: https://docs.kernel.org/tools/rtla/rtla.html

This is an initial integration into test-definitions, following the rt-tests as mach as possible (even faking the JSON format output). Maybe upstream will add support for native JSON output but until let's role with this format.

I haven't added any access to any command line options except the duration argument for this version. The aim is to get first some sane defaults figured out.

These tests depend on following kernel options:

```
CONFIG_OSNOISE_TRACER=y
CONFIG_TIMERLAT_TRACER=y
CONFIG_HIST_TRIGGERS=y
```

![image](https://user-images.githubusercontent.com/1050803/176653209-e651d9a3-9f34-4e70-96f6-7bdd78848c3a.png)

