### PR TITLE
automated: linux: add libcurl SAN-less test

### DIFF
--- a/automated/linux/libcurl/Dockerfile
+++ b/automated/linux/libcurl/Dockerfile
@@ -1,0 +1,5 @@
+FROM httpd:latest
+
+COPY httpd.conf /usr/local/apache2/conf/httpd.conf
+COPY server.crt /usr/local/apache2/conf/
+COPY server.key /usr/local/apache2/conf/

--- a/automated/linux/libcurl/README.md
+++ b/automated/linux/libcurl/README.md
@@ -1,0 +1,15 @@
+Generate self signed certificate without SAN extensions
+
+```
+openssl genrsa -aes256 -passout pass:gsahdg -out server.pass.key 4096
+openssl rsa -passin pass:gsahdg -in server.pass.key -out server.key
+rm server.pass.key
+openssl req -new -key server.key -out server.csr -subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=localhost"
+openssl x509 -req -sha256 -days 3650 -in server.csr -signkey server.key -out server.crt
+```
+
+Make curl trust the generated certificate
+
+```
+curl --cacert server.crt  --output index.html https://localhost
+```

--- a/automated/linux/libcurl/httpd.conf
+++ b/automated/linux/libcurl/httpd.conf
@@ -1,0 +1,140 @@
+#
+# This is the main Apache HTTP server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
+# In particular, see 
+# <URL:http://httpd.apache.org/docs/2.4/mod/directives.html>
+# for a discussion of each configuration directive.
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# Configuration and logfile names: If the filenames you specify for many
+# of the server's control files begin with "/" (or "drive:/" for Win32), the
+# server will use that explicit path.  If the filenames do *not* begin
+# with "/", the value of ServerRoot is prepended -- so "logs/access_log"
+# with ServerRoot set to "/usr/local/apache2" will be interpreted by the
+# server as "/usr/local/apache2/logs/access_log", whereas "/logs/access_log" 
+# will be interpreted as '/logs/access_log'.
+
+ServerRoot "/usr/local/apache2"
+
+#
+#Listen 12.34.56.78:80
+Listen 80
+
+#
+# Dynamic Shared Object (DSO) Support
+#
+# To be able to use the functionality of a module which was built as a DSO you
+# have to place corresponding `LoadModule' lines at this location so the
+# directives contained in it are actually available _before_ they are used.
+# Statically compiled modules (those listed by `httpd -l') do not need
+# to be loaded here.
+#
+# Example:
+# LoadModule foo_module modules/mod_foo.so
+#
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+LoadModule filter_module modules/mod_filter.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule env_module modules/mod_env.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule version_module modules/mod_version.so
+LoadModule ssl_module modules/mod_ssl.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule alias_module modules/mod_alias.so
+
+<IfModule unixd_module>
+User daemon
+Group daemon
+</IfModule>
+ServerAdmin you@example.com
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+DocumentRoot "/usr/local/apache2/htdocs"
+<Directory "/usr/local/apache2/htdocs">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+<Files ".ht*">
+    Require all denied
+</Files>
+
+ErrorLog /proc/self/fd/2
+
+LogLevel warn
+
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+      # You need to enable mod_logio.c to use %I and %O
+      LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    CustomLog /proc/self/fd/1 common
+
+    #CustomLog "logs/access_log" combined
+</IfModule>
+
+<IfModule alias_module>
+    ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
+</IfModule>
+
+
+<Directory "/usr/local/apache2/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    RequestHeader unset Proxy early
+</IfModule>
+
+<IfModule mime_module>
+    TypesConfig conf/mime.types
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+</IfModule>
+
+
+<IfModule proxy_html_module>
+Include conf/extra/proxy-html.conf
+</IfModule>
+
+# Secure (SSL/TLS) connections
+Include conf/extra/httpd-ssl.conf
+
+<IfModule ssl_module>
+SSLRandomSeed startup builtin
+SSLRandomSeed connect builtin
+</IfModule>
+

--- a/automated/linux/libcurl/libcurl.sh
+++ b/automated/linux/libcurl/libcurl.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2022 Foundries.io Ltd.
+
+# shellcheck disable=SC1091
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+export RESULT_FILE
+
+usage() {
+    echo "Usage: $0 [-s <true|false>]" 1>&2
+    exit 1
+}
+
+while getopts "s:" o; do
+  case "$o" in
+    s) SKIP_INSTALL="${OPTARG}" ;;
+    *) usage ;;
+  esac
+done
+
+# Install lamp and use systemctl for service management. Tested on Ubuntu 16.04,
+# Debian 8, CentOS 7 and Fedora 24. systemctl should available on newer releases
+# as well.
+if [ "${SKIP_INSTALL}" = "True" ] || [ "${SKIP_INSTALL}" = "true" ]; then
+    warn_msg "Dependencies installation skipped."
+else
+    dist_name
+    # shellcheck disable=SC2154
+    case "${dist}" in
+      debian|ubuntu)
+        pkgs="docker.io curl openssl"
+        install_deps "${pkgs}"
+        ;;
+      centos|fedora)
+        pkgs="docker curl openssl"
+        install_deps "${pkgs}"
+        ;;
+      *)
+        error_msg "Unsupported distribution!"
+    esac
+fi
+
+! check_root && error_msg "You need to be root to run this script."
+create_out_dir "${OUTPUT}"
+
+# generate certificate
+openssl genrsa -aes256 -passout pass:gsahdg -out server.pass.key 4096
+check_return "openssl-generate-key-password"
+openssl rsa -passin pass:gsahdg -in server.pass.key -out server.key
+check_return "openssl-generate-key"
+openssl req -new -key server.key -out server.csr -subj "/C=US/OU=Org/CN=localhost"
+check_return "openssl-generate-csr"
+openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt
+check_return "openssl-generate-crt"
+
+# build docker container
+docker build --tag myhttpd .
+check_return "build-httpd-container"
+
+# start docker container
+docker run --name myhttpd_curl -d -p 443:443 myhttpd
+check_return "start-httpd-container"
+
+# wait 15 seconds to allow container to fully start
+sleep 15
+# test curl
+curl --cacert server.crt  --output index.html https://localhost
+check_return "curl-get-self-signed-cert"
+
+# stop docker
+docker stop myhttpd_curl
+
+# cleanup
+rm server.pass.key
+rm server.key
+rm server.csr
+rm server.crt
+docker stop myhttpd_curl

--- a/automated/linux/libcurl/libcurl.yaml
+++ b/automated/linux/libcurl/libcurl.yaml
@@ -1,0 +1,26 @@
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: libcurl
+    description: "Test exercising libcurl support
+        for certificates without SAN"
+    maintainer:
+        - milosz.wasilewski@foundries.io
+    os:
+        - debian
+        - ubuntu
+        - centos
+        - fedora
+    scope:
+        - functional
+    devices:
+        - imx8mm-evk
+        - imx6ull-evk
+
+params:
+    SKIP_INSTALL: "False"
+
+run:
+    steps:
+        - cd ./automated/linux/libcurl/
+        - ./libcurl.sh -s "${SKIP_INSTALL}"
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
This test covers the bug in libcurl that results in Out of memory
exception when dealing with HTTPS server with self-signed certificate.
When certificate lacks SAN fieds, libcurl would quit. Github error:
https://github.com/curl/curl/issues/8559

The bug was fixed in libcurl:
https://github.com/curl/curl/pull/8560

The fix is not propagated to all distros yet (as of July 2022).

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>