### PR TITLE
automated: linux: ota update/rollback variable fix

### DIFF
--- a/automated/linux/ota-rollback/download-update.sh
+++ b/automated/linux/ota-rollback/download-update.sh
@@ -49,6 +49,11 @@ done
 ! check_root && error_msg "You need to be root to run this script."
 create_out_dir "${OUTPUT}"
 
+SECONDARY_BOOT_VAR_NAME="fiovb.is_secondary_boot"
+if [ "${UBOOT_VAR_TOOL}" != "fw_printenv" ]; then
+    SECONDARY_BOOT_VAR_NAME="is_secondary_boot"
+fi
+
 ref_bootcount_before_download=0
 ref_rollback_before_download=0
 ref_bootupgrade_available_before_download=0
@@ -107,7 +112,7 @@ if [ -f /usr/lib/firmware/version.txt ]; then
     bootfirmware_version_before_download=$(uboot_variable_value bootfirmware_version)
     # shellcheck disable=SC2154
     compare_test_value "${TYPE}_bootfirmware_version_before_download" "${bootfirmware_version}" "${bootfirmware_version_before_download}"
-    fiovb_is_secondary_boot_before_download=$(uboot_variable_value fiovb.is_secondary_boot)
+    fiovb_is_secondary_boot_before_download=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
     compare_test_value "${TYPE}_fiovb_is_secondary_boot_before_download" "${ref_fiovb_is_secondary_boot_before_download}" "${fiovb_is_secondary_boot_before_download}"
 else
     report_skip "${TYPE}_bootupgrade_available_before_download"
@@ -151,7 +156,7 @@ if [ -f /usr/lib/firmware/version.txt ]; then
     bootfirmware_version_after_download=$(uboot_variable_value bootfirmware_version)
     # shellcheck disable=SC2154
     compare_test_value "${TYPE}_bootfirmware_version_after_download" "${ref_bootfirmware_version_after_download}" "${bootfirmware_version_after_download}"
-    fiovb_is_secondary_boot_after_download=$(uboot_variable_value fiovb.is_secondary_boot)
+    fiovb_is_secondary_boot_after_download=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
     compare_test_value "${TYPE}_fiovb_is_secondary_boot_after_download" "${ref_fiovb_is_secondary_boot_after_download}" "${fiovb_is_secondary_boot_after_download}"
 else
     report_skip "${TYPE}_bootupgrade_available_after_download"

--- a/automated/linux/ota-rollback/verify-reboot.sh
+++ b/automated/linux/ota-rollback/verify-reboot.sh
@@ -50,6 +50,11 @@ done
 ! check_root && error_msg "You need to be root to run this script."
 create_out_dir "${OUTPUT}"
 
+SECONDARY_BOOT_VAR_NAME="fiovb.is_secondary_boot"
+if [ "${UBOOT_VAR_TOOL}" != "fw_printenv" ]; then
+    SECONDARY_BOOT_VAR_NAME="is_secondary_boot"
+fi
+
 ref_bootcount_after_reboot=4
 ref_rollback_after_reboot=1
 ref_bootupgrade_available_after_reboot=0
@@ -79,7 +84,7 @@ if [ -f /usr/lib/firmware/version.txt ]; then
     bootfirmware_version_after_reboot=$(uboot_variable_value bootfirmware_version)
     # shellcheck disable=SC2154
     compare_test_value "bootfirmware_version_after_reboot" "${ref_bootfirmware_version_after_reboot}" "${bootfirmware_version_after_reboot}"
-    fiovb_is_secondary_boot_after_reboot=$(uboot_variable_value fiovb.is_secondary_boot)
+    fiovb_is_secondary_boot_after_reboot=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
     compare_test_value "fiovb_is_secondary_boot_after_reboot" "${ref_fiovb_is_secondary_boot_after_reboot}" "${fiovb_is_secondary_boot_after_reboot}"
 else
     report_skip "bootupgrade_available_after_reboot"

--- a/automated/linux/ota-rollback/verify-rollback.sh
+++ b/automated/linux/ota-rollback/verify-rollback.sh
@@ -47,6 +47,11 @@ done
 ! check_root && error_msg "You need to be root to run this script."
 create_out_dir "${OUTPUT}"
 
+SECONDARY_BOOT_VAR_NAME="fiovb.is_secondary_boot"
+if [ "${UBOOT_VAR_TOOL}" != "fw_printenv" ]; then
+    SECONDARY_BOOT_VAR_NAME="is_secondary_boot"
+fi
+
 ref_bootcount_after_rollback=4
 ref_rollback_after_rollback=1
 ref_bootupgrade_available_after_rollback=0
@@ -73,7 +78,7 @@ if [ -f /usr/lib/firmware/version.txt ]; then
     bootfirmware_version_after_rollback=$(uboot_variable_value bootfirmware_version)
     # shellcheck disable=SC2154
     compare_test_value "bootfirmware_version_after_rollback" "${ref_bootfirmware_version_after_rollback}" "${bootfirmware_version_after_rollback}"
-    fiovb_is_secondary_boot_after_rollback=$(uboot_variable_value fiovb.is_secondary_boot)
+    fiovb_is_secondary_boot_after_rollback=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
     compare_test_value "fiovb_is_secondary_boot_after_rollback" "${ref_fiovb_is_secondary_boot_after_rollback}" "${fiovb_is_secondary_boot_after_rollback}"
 else
     report_skip "bootupgrade_available_after_rollback"

--- a/automated/linux/ota-update/download-update.sh
+++ b/automated/linux/ota-update/download-update.sh
@@ -49,6 +49,11 @@ done
 ! check_root && error_msg "You need to be root to run this script."
 create_out_dir "${OUTPUT}"
 
+SECONDARY_BOOT_VAR_NAME="fiovb.is_secondary_boot"
+if [ "${UBOOT_VAR_TOOL}" != "fw_printenv" ]; then
+    SECONDARY_BOOT_VAR_NAME="is_secondary_boot"
+fi
+
 ref_bootcount_before_download=0
 ref_rollback_before_download=0
 ref_bootupgrade_available_before_download=0
@@ -107,7 +112,7 @@ if [ -f /usr/lib/firmware/version.txt ]; then
     bootfirmware_version_before_download=$(uboot_variable_value bootfirmware_version)
     # shellcheck disable=SC2154
     compare_test_value "${TYPE}_bootfirmware_version_before_download" "${bootfirmware_version}" "${bootfirmware_version_before_download}"
-    fiovb_is_secondary_boot_before_download=$(uboot_variable_value fiovb.is_secondary_boot)
+    fiovb_is_secondary_boot_before_download=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
     compare_test_value "${TYPE}_fiovb_is_secondary_boot_before_download" "${ref_fiovb_is_secondary_boot_before_download}" "${fiovb_is_secondary_boot_before_download}"
 else
     report_skip "${TYPE}_bootupgrade_available_before_download"
@@ -151,7 +156,7 @@ if [ -f /usr/lib/firmware/version.txt ]; then
     bootfirmware_version_after_download=$(uboot_variable_value bootfirmware_version)
     # shellcheck disable=SC2154
     compare_test_value "${TYPE}_bootfirmware_version_after_download" "${ref_bootfirmware_version_after_download}" "${bootfirmware_version_after_download}"
-    fiovb_is_secondary_boot_after_download=$(uboot_variable_value fiovb.is_secondary_boot)
+    fiovb_is_secondary_boot_after_download=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
     compare_test_value "${TYPE}_fiovb_is_secondary_boot_after_download" "${ref_fiovb_is_secondary_boot_after_download}" "${fiovb_is_secondary_boot_after_download}"
 else
     report_skip "${TYPE}_bootupgrade_available_after_download"

--- a/automated/linux/ota-update/verify-reboot.sh
+++ b/automated/linux/ota-update/verify-reboot.sh
@@ -45,6 +45,11 @@ done
 ! check_root && error_msg "You need to be root to run this script."
 create_out_dir "${OUTPUT}"
 
+SECONDARY_BOOT_VAR_NAME="fiovb.is_secondary_boot"
+if [ "${UBOOT_VAR_TOOL}" != "fw_printenv" ]; then
+    SECONDARY_BOOT_VAR_NAME="is_secondary_boot"
+fi
+
 ref_bootcount_after_upgrade=0
 ref_rollback_after_upgrade=0
 ref_bootupgrade_available_after_upgrade=0
@@ -65,7 +70,7 @@ bootupgrade_available_after_upgrade=$(uboot_variable_value bootupgrade_available
 compare_test_value "bootupgrade_available_after_upgrade" "${ref_bootupgrade_available_after_upgrade}" "${bootupgrade_available_after_upgrade}"
 bootfirmware_version_after_upgrade=$(uboot_variable_value bootfirmware_version)
 compare_test_value "bootfirmware_version_after_upgrade" "${ref_bootfirmware_version_after_upgrade}" "${bootfirmware_version_after_upgrade}"
-fiovb_is_secondary_boot_after_upgrade=$(uboot_variable_value fiovb.is_secondary_boot)
+fiovb_is_secondary_boot_after_upgrade=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
 compare_test_value "fiovb_is_secondary_boot_after_upgrade" "${ref_fiovb_is_secondary_boot_after_upgrade}" "${fiovb_is_secondary_boot_after_upgrade}"
 
 . /etc/os-release

--- a/automated/linux/ota-update/verify-update.sh
+++ b/automated/linux/ota-update/verify-update.sh
@@ -50,6 +50,11 @@ done
 ! check_root && error_msg "You need to be root to run this script."
 create_out_dir "${OUTPUT}"
 
+SECONDARY_BOOT_VAR_NAME="fiovb.is_secondary_boot"
+if [ "${UBOOT_VAR_TOOL}" != "fw_printenv" ]; then
+    SECONDARY_BOOT_VAR_NAME="is_secondary_boot"
+fi
+
 ref_bootcount_after_upgrade=0
 ref_rollback_after_upgrade=0
 ref_bootupgrade_available_after_upgrade=0
@@ -78,7 +83,7 @@ bootupgrade_available_after_upgrade=$(uboot_variable_value bootupgrade_available
 compare_test_value "bootupgrade_available_after_upgrade" "${ref_bootupgrade_available_after_upgrade}" "${bootupgrade_available_after_upgrade}"
 bootfirmware_version_after_upgrade=$(uboot_variable_value bootfirmware_version)
 compare_test_value "bootfirmware_version_after_upgrade" "${ref_bootfirmware_version_after_upgrade}" "${bootfirmware_version_after_upgrade}"
-fiovb_is_secondary_boot_after_upgrade=$(uboot_variable_value fiovb.is_secondary_boot)
+fiovb_is_secondary_boot_after_upgrade=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
 compare_test_value "fiovb_is_secondary_boot_after_upgrade" "${ref_fiovb_is_secondary_boot_after_upgrade}" "${fiovb_is_secondary_boot_after_upgrade}"
 
 . /etc/os-release


### PR DESCRIPTION
When performing OTA update/rollback on open board variables are kept in
u-boot env. When the same is performed on a closed board, variables are
kept in RPMB. Due to historical reasons the "fiovb" prefix is not
present in RPMB variables. This patch aligns the current behaviour of
the test with the software.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>