### PR TITLE
initialize_adb: unset ANDROID_SERIAL before get-serialno

### DIFF
--- a/automated/lib/android-test-lib
+++ b/automated/lib/android-test-lib
@@ -43,6 +43,7 @@ initialize_adb() {
         if [ "${number}" -gt 1 ]; then
             error_msg "More than one device or emulator found! Please set ANDROID_SERIAL from test script."
         elif [ "${number}" -eq 1 ]; then
+            unset ANDROID_SERIAL
             ANDROID_SERIAL="$(adb get-serialno)"
         else
             error_msg "Device NOT found"


### PR DESCRIPTION
when ANDROID_SERIAL is empty, to work around the following problem
    ++ adb get-serialno
    error: device '' not found
    + ANDROID_SERIAL=

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>