### PR TITLE
automated/linux/measured-boot: adding measured-boot test cases

### DIFF
--- a/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
+++ b/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
@@ -1,0 +1,29 @@
+metadata:
+    name: measured-boot-changed-PCR7
+    format: "Lava-Test Test Definition 1.0"
+    description: "Checking PCR7 value for measured boot testing"
+    maintainer:
+        - theodore.grey@linaro.org
+    os:
+        - any-linux
+    scope:
+        - functional
+    devices:
+        - qemu
+
+interactive:
+- name: basic-cmds
+  prompts: ['=> ', 'Booting:']
+  script:
+  - command: ""
+  - command: "printenv"
+  - command: ""
+  - command: "mw.b 0x50000000 a"
+  - command: ""
+  - command: "tpm init"
+  - command: ""
+  - command: "tpm startup TPM2_SU_CLEAR"
+  - command: ""
+  - command: "tpm pcr_extend 7 0x50000000"
+  - command: ""
+  - command: "bootefi bootmgr"

--- a/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
+++ b/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
@@ -26,4 +26,3 @@ interactive:
   - command: ""
   - command: "tpm pcr_extend 7 0x50000000"
   - command: ""
-  - command: "bootefi bootmgr"

--- a/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
+++ b/automated/linux/measured-boot/measured-boot-enable-badboot.yaml
@@ -26,3 +26,4 @@ interactive:
   - command: ""
   - command: "tpm pcr_extend 7 0x50000000"
   - command: ""
+  - command: "bootefi bootmgr"

--- a/automated/linux/measured-boot/measured-boot-enable-check-PCR7.yaml
+++ b/automated/linux/measured-boot/measured-boot-enable-check-PCR7.yaml
@@ -1,0 +1,16 @@
+metadata:
+    name: measured-boot-enabled-PCR7
+    format: "Lava-Test Test Definition 1.0"
+    description: "Checking PCR7 value for measured boot testing"
+    maintainer:
+        - theodore.grey@linaro.org
+    os:
+        - any-linux
+    scope:
+        - functional
+    devices:
+        - qemu
+run:
+    steps:
+    - sudo tpm2_pcrread sha256:7
+    - sudo shutdown

--- a/manual/measured-boot/check-measured-boot-enabled.yaml
+++ b/manual/measured-boot/check-measured-boot-enabled.yaml
@@ -1,0 +1,22 @@
+metadata:
+    name: measured-boot-enabled-check
+    format: "Manual Test Definition 1.0"
+    description: "Booting TS image with an artificially changed PCR7 value. If measured boot is enabled the board wont boot."
+    maintainer:
+        - theodore.grey@linaro.org
+    os:
+        - any-linux
+    scope:
+        - functional
+    devices:
+        - qemu
+    environment:
+        - manual-test
+run:
+    steps:
+        - Device will boot from the bootefi bootmgr command
+
+    expected:
+        - While booting, if measured boot is enabled, there should be an error 'tpm:parameter(1):integrity check failed'
+        - The device will then give an error 'Unable to run tpm2_load' before giving a stack trace and rebooting to u-boot shell.
+        - If device doesnt give an error and instead boots to command line, measured-boot is not enabled.


### PR DESCRIPTION
Creating measured boot test cases for trusted substrate check that measured boot is enabled.

measured-boot-enabled-check-PCR7.yaml checks the value in PCR7 and reboots the device.
measured-boot-enabled-badboot.yaml changes the PCR7 value and afterwards it boots the device with the bad value.

If measured boot from TS is enabled the device should not boot. If it does boot, run check-PCR7 again to make sure PCR7 value has actually changed.