### PR TITLE
test-runner.py: report also distro version from /etc/os-release

### DIFF
--- a/automated/utils/test-runner.py
+++ b/automated/utils/test-runner.py
@@ -679,6 +679,7 @@ def get_environment(target=None, skip_collection=False):
         "board_vendor": "Huawei",
         "kernel": "4.9.0-20.gitedc2a1c.linaro.aarch64",
         "linux_distribution": "centos",
+        "linux_distribution_version": "6.2",
         "packages": [
             "GeoIP-1.5.0-11.el7",
             "NetworkManager-1.4.0-20.el7_3",
@@ -702,6 +703,33 @@ def get_environment(target=None, skip_collection=False):
         )
     except subprocess.CalledProcessError:
         environment["linux_distribution"] = ""
+
+    try:
+        environment["linux_distribution_version"] = (
+            run_command("grep ^VERSION= /etc/os-release", target)
+            .split("=")[-1]
+            .strip('"')
+        )
+    except subprocess.CalledProcessError:
+        environment["linux_distribution_version"] = ""
+
+    try:
+        environment["linux_distribution_version_id"] = (
+            run_command("grep ^VERSION_ID= /etc/os-release", target)
+            .split("=")[-1]
+            .strip('"')
+        )
+    except subprocess.CalledProcessError:
+        environment["linux_distribution_version_id"] = ""
+
+    try:
+        environment["linux_distribution_version_codename"] = (
+            run_command("grep ^VERSION_CODENAME= /etc/os-release", target)
+            .split("=")[-1]
+            .strip('"')
+        )
+    except subprocess.CalledProcessError:
+        environment["linux_distribution_version_codename"] = ""
 
     try:
         environment["kernel"] = run_command("uname -r", target)


### PR DESCRIPTION
For example with yocto/poky/oe rootfs images, this variable contains the system version:

root@qemux86-64:~# cat /etc/os-release
ID=poky
NAME="Poky (Yocto Project Reference Distro)"
VERSION="4.1+snapshot-e7619f7650e1f545dccba327bbc8d03a7b34fc4e (langdale)" VERSION_ID=4.1-snapshot-e7619f7650e1f545dccba327bbc8d03a7b34fc4e PRETTY_NAME="Poky (Yocto Project Reference Distro) 4.1+snapshot-e7619f7650e1f545dccba327bbc8d03a7b34fc4e (langdale)" DISTRO_CODENAME="langdale"

On old Ubuntu 18.04 this is:

$ cat /etc/os-release
NAME="Ubuntu"
VERSION="18.04.6 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.6 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/" PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy" VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic

New Debian 12 may not ship VERSION field though:

$ cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux bookworm/sid"
NAME="Debian GNU/Linux"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

Thus capture VERSION, VERSION_ID and VERSION_CODENAME.

Signed-off-by: Mikko Rapeli <mikko.rapeli@linaro.org>