### PR TITLE
test-writing-guidelines.md: fix headings

### DIFF
--- a/docs/test-writing-guidelines.md
+++ b/docs/test-writing-guidelines.md
@@ -1,10 +1,10 @@
-#Test Writing Guidelines
+# Test Writing Guidelines
 
 This document describes guidelines and is intended for anybody who wants to write
 or modify a test case. It's not a definitive guide and it's not, by any means, a
 substitute for common sense.
 
-##General Rules
+## General Rules
 
 ### 1. Simplicity
 


### PR DESCRIPTION
Wiki syntax requires space after heading hash.
See rendered output on
https://github.com/Linaro/test-definitions/blob/master/docs/test-writing-guidelines.md

Signed-off-by: Mikko Rapeli <mikko.rapeli@linaro.org>