### PR TITLE
Revert "tradefed.sh: pass --no-cache to wget"

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -59,7 +59,7 @@ disable_suspend
 
 # Download CTS/VTS test package or copy it from local disk.
 if echo "${TEST_URL}" | grep "^http" ; then
-    wget --no-cache -S --progress=dot:giga "${TEST_URL}"
+    wget -S --progress=dot:giga "${TEST_URL}"
 else
     cp "${TEST_URL}" ./
 fi


### PR DESCRIPTION
This reverts commit 1e5f85192b08fd3a9c4ff91e522ff4e00dffdac6. Reason: according to what Kelley said:
    yes, we just need to clear the current cache entry for the old S3 url
    after that, the caching settings should prevent those from being saved
    so I think one successful run with --no-cache, and subsequent runs are good to go

Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>