### PR TITLE
kselftest: support sharding of kselftest's subsuites

### DIFF
--- a/automated/linux/kselftest/kselftest.yaml
+++ b/automated/linux/kselftest/kselftest.yaml
@@ -51,9 +51,14 @@ params:
     BRANCH: ""
     ENVIRONMENT: ""
 
+    # Number of shards that will be done, default 1 which is the same as no sharding.
+    SHARD_NUMBER: 1
+
+    # Which bucket to run, default '1' which is the same as no sharding, run it as LTP upstream decides.
+    SHARD_INDEX: 1
 
 run:
     steps:
         - cd ./automated/linux/kselftest/
-        - ./kselftest.sh -c "${TST_CMDFILES}" -T "${TST_CASENAME}" -t "${TESTPROG}" -s "${SKIP_INSTALL}" -u "${TESTPROG_URL}" -L "${SKIPLIST}" -S "${SKIPFILE}" -b "${BOARD}" -g "${BRANCH}" -e "${ENVIRONMENT}" -p "${KSELFTEST_PATH}"
+        - ./kselftest.sh -c "${TST_CMDFILES}" -T "${TST_CASENAME}" -t "${TESTPROG}" -s "${SKIP_INSTALL}" -u "${TESTPROG_URL}" -L "${SKIPLIST}" -S "${SKIPFILE}" -b "${BOARD}" -g "${BRANCH}" -e "${ENVIRONMENT}" -p "${KSELFTEST_PATH}" -n "${SHARD_NUMBER}" -i "${SHARD_INDEX}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
    This will improve the test time if running kselftest's subsuites.
    With 'SHARD_NUMBER' set to 10, that will split up the subsuite in 10
    buckets, and if 10 jobs gets created and run on 10 different devices
    with different 'SHARD_INDEX' set from 1, 2, ..., 9, 10 that will
    speed up the overall run of that subsuite.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>