### PR TITLE
automated: libs: parse_rt_tests_results.py: Update shebang from python to python3

### DIFF
--- a/automated/lib/parse_rt_tests_results.py
+++ b/automated/lib/parse_rt_tests_results.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 #
 # MIT License


### PR DESCRIPTION
parse_rt_tests_results.py has not migrated to python3. This update the shebang to python3.

Signed-off-by: Nobuhiro Iwamatsu <nobuhiro1.iwamatsu@toshiba.co.jp>