### PR TITLE
secure-boot: Fix link to UEFI specs

### DIFF
--- a/automated/linux/secure-boot/secure-boot-enabled.yaml
+++ b/automated/linux/secure-boot/secure-boot-enabled.yaml
@@ -4,8 +4,8 @@ metadata:
   description: |
     Validate UEFI SecureBoot is enabled by checking the value of variable
     8be4df61-93ca-11d2-aa0d-00e098032b8c-SecureBoot. This long variable is
-    predefined in the UEFI standard and it will never change. Check page 82
-    from https://shorturl.at/fpLV6
+    predefined in the UEFI standard and it will never change. Refer to
+    https://uefi.org/specs/UEFI/2.10/03_Boot_Manager.html#globally-defined-variables
   maintainer:
     - javier.tia@linaro.org
   os:


### PR DESCRIPTION
This PR fixes the link to the UEFI specifications in the `secure-boot-enabled.yaml` file.

The [old link](https://shorturl.at/fpLV6) does not actually redirect to the PDF file of the UEFI specifications. Instead, it leads to a Google search page for "fitzroy falls walk".

Instead of linking to a PDF file, this PR links to the HTML version of the UEFI specifications to make it more easily navigable.

Signed-off-by: James R T <jamestiotio@gmail.com>