### PR TITLE
automated: linux: allow ostree to keep single kernel

### DIFF
--- a/automated/linux/ota-rollback/download-update.sh
+++ b/automated/linux/ota-rollback/download-update.sh
@@ -204,9 +204,20 @@ if [ "${UPGRADE_AVAILABLE}" -eq 1 ]; then
         cat /boot/loader/uEnv.txt
         . /boot/loader/uEnv.txt
         # shellcheck disable=SC2154
-        echo "Corrupting kernel image ${kernel_image}"
-        # shellcheck disable=SC2154
-        echo bad > "${kernel_image}"
+        if [ "${kernel_image}" = "${kernel_image2}" ]; then
+            # when there is just one kernel, create a fake one and update uEnv.txt
+            # shellcheck disable=SC2154
+            kernel_dirname=$(dirname "${kernel_image}")
+            # shellcheck disable=SC2154
+            echo "bad" > "${kernel_dirname}/vmlinuz-corrupt"
+            # shellcheck disable=SC2154
+            sed -i "s|kernel_image=${kernel_image}|kernel_image=${kernel_dirname}/vmlinuz-corrupt|g" /boot/loader/uEnv.txt
+        else
+            # shellcheck disable=SC2154
+            echo "Corrupting kernel image ${kernel_image}"
+            # shellcheck disable=SC2154
+            echo bad > "${kernel_image}"
+        fi
     fi
 else
     lava-test-raise "No-update-available-${TYPE}"


### PR DESCRIPTION
When doing OTA upgrade ostree might decide that kernel image didn't change and keep just single file for "old" and "new" sysroot versions. This means that corrupting the kernel will brick the board and the rollback wouldn't be possible. This patch addresses the issue by creating a "fake" kernel and updating uEnv.txt. This is a bit more invasive than the previous approach but seems to be the simplest way of forcing "bad kernel" based rollback.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@foundries.io>