### PR TITLE
automated: linux: kselftest: don't overwrite file

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -223,8 +223,8 @@ elif [ -n "${TST_CMDFILES}" ]; then
     # shellcheck disable=SC2086
     for test in ${TST_CMDFILES}; do
         cp kselftest-list.txt.skips kselftest-list.txt
-        grep "^${test}:" kselftest-list.txt | tee kselftest-list.txt
-        split --verbose --numeric-suffixes=1 -n l/"${SHARD_INDEX}"/"${SHARD_NUMBER}" kselftest-list.txt > shardfile
+        grep "^${test}:" kselftest-list.txt | tee kselftest-list.tmp
+        split --verbose --numeric-suffixes=1 -n l/"${SHARD_INDEX}"/"${SHARD_NUMBER}" kselftest-list.tmp > shardfile
         echo "============== Tests to run ==============="
         cat shardfile
         echo "===========End Tests to run ==============="


### PR DESCRIPTION
When searching for 'sub-tests' in kselftest-list.txt don't write back to the same file, use a kselftest-list.tmp file.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>