### PR TITLE
automated: linux: ptest: Fix test names reporting and timeout

### DIFF
--- a/automated/linux/ptest/ptest.py
+++ b/automated/linux/ptest/ptest.py
@@ -122,9 +122,11 @@ def run_ptest(command):
     return rc, results
 
 
-def check_ptest(ptest_dir, ptest_name, output_log):
+def check_ptest(ptest_dir, ptest_name, ptest_timeout, output_log):
     log_name = os.path.join(os.getcwd(), "%s.log" % ptest_name)
-    status, results = run_ptest("ptest-runner -d %s %s" % (ptest_dir, ptest_name))
+    status, results = run_ptest(
+        "ptest-runner -t %s -d %s %s" % (ptest_timeout, ptest_dir, ptest_name)
+    )
 
     with open(output_log, "a+") as f:
         f.write("lava-test-set start %s\n" % ptest_name)
@@ -142,6 +144,13 @@ def main():
     )
     parser.add_argument(
         "-e", "--exclude", action="store", nargs="*", help="Ptests to exclude"
+    )
+    parser.add_argument(
+        "-T",
+        "--ptest-timeout",
+        help="Timeout [s] value passed to ptest-runner (optional)",
+        action="store",
+        default=300,
     )
     parser.add_argument(
         "-d",
@@ -191,7 +200,7 @@ def main():
     required_ptests = dict.fromkeys(tests, False)
     ptests_to_run = filter_ptests(ptests, required_ptests, exclude)
     for ptest_name in ptests_to_run:
-        check_ptest(ptest_dir, ptest_name, args.output_log)
+        check_ptest(ptest_dir, ptest_name, args.ptest_timeout, args.output_log)
 
     return 0
 

--- a/automated/linux/ptest/ptest.py
+++ b/automated/linux/ptest/ptest.py
@@ -131,7 +131,7 @@ def check_ptest(ptest_dir, ptest_name, output_log):
         f.write("%s %s\n" % (ptest_name, "pass" if status == 0 else "fail"))
         for test, test_status in results:
             test = test.encode("ascii", errors="ignore").decode()
-            f.write("%s %s\n" % (re.sub(r"[^\w-]", "", test), test_status))
+            f.write("%s %s\n" % (re.sub(r"\s+", "_", test.strip()), test_status))
         f.write("lava-test-set stop %s\n" % ptest_name)
 
 

--- a/automated/linux/ptest/ptest.yaml
+++ b/automated/linux/ptest/ptest.yaml
@@ -17,9 +17,10 @@ metadata:
 params:
     TESTS: ""
     EXCLUDE: ""
+    PTEST_TIMEOUT: 300
 
 run:
     steps:
         - cd ./automated/linux/ptest
-        - PYTHONIOENCODING=UTF-8 ./ptest.py -o ./result.txt -t ${TESTS} -e ${EXCLUDE}
+        - PYTHONIOENCODING=UTF-8 ./ptest.py -T ${PTEST_TIMEOUT} -o ./result.txt -t ${TESTS} -e ${EXCLUDE}
         - ../../utils/send-to-lava.sh ./result.txt


### PR DESCRIPTION
This PR fixes:
- ptest-runner timeouts on slower machines, by allowing to specify timeout
- merging test names containing spaces in a single word