### PR TITLE
ltp: sharding: remove the tmp file before creation

### DIFF
--- a/automated/linux/ltp/ltp.sh
+++ b/automated/linux/ltp/ltp.sh
@@ -183,6 +183,7 @@ run_ltp() {
     # Cleanup
     # don't fail the whole test job if rm fails
     rm -rf "${LTP_TMPDIR}" || true
+    rm -rf alltests || true
 }
 
 # Prepare system


### PR DESCRIPTION
When running multiple tests in different test sections in the LAVA job definition file, the alltests file was only adding more and more tests to the file. Which lead to that the first tests that was added was running in all the following tests as well.

Ensuring to delete the 'alltests' file before generating the file, will fix the problem of running the same set of tests in the following test runs.

Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>