### PR TITLE
send-to-lava: Speed up parsing of simple test results

### DIFF
--- a/automated/utils/send-to-lava.sh
+++ b/automated/utils/send-to-lava.sh
@@ -10,8 +10,8 @@ lava_test_set="$?"
 if [ -f "${RESULT_FILE}" ]; then
     while read -r line; do
         if echo "${line}" | grep -iq -E ".* +(pass|fail|skip|unknown)$"; then
-            test="$(echo "${line}" | awk '{print $1}')"
-            result="$(echo "${line}" | awk '{print $2}')"
+            test="${line%% *}"
+            result="${line##* }"
 
             if [ "${lava_test_case}" -eq 0 ]; then
                 lava-test-case "${test}" --result "${result}"


### PR DESCRIPTION
Instead of launching a subshell with `echo` piped through `awk`, use shell expression expansion to retrieve the test name and the test result.

In simple cases where there are mostly PASS/FAIL/SKIP results, this is a speed-up improvement of +80%.