### PR TITLE
automated: kselftest: update parser

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -128,34 +128,7 @@ fi
 
 
 parse_output() {
-    perl -ne '
-    if (m|^# selftests: (.*)$|) {
-	$testdir = $1;
-	$testdir =~ s|[:/]\s*|.|g;
-    } elsif (m|^(?:# )*(not )?ok (?:\d+) ([^#]+)(# (SKIP)?)?|) {
-        $not = $1;
-        $test = $2;
-        $skip = $4;
-        $test =~ s|\s+$||;
-        # If the test name starts with "selftests: " it is "fully qualified".
-        if ($test =~ /selftests: (.*)/) {
-            $test = $1;
-	    $test =~ s|[:/]\s*|.|g;
-        } else {
-            # Otherwise, it likely needs the testdir prepended.
-            $test = "$testdir.$test";
-        }
-        # Any appearance of the SKIP is a skip.
-        if ($skip eq "SKIP") {
-            $result="skip";
-        } elsif ($not eq "not ") {
-            $result="fail";
-        } else {
-            $result="pass";
-        }
-	print "$test $result\n";
-    }
-' "${LOGFILE}" >> "${RESULT_FILE}"
+    ./parse-output.py < "${LOGFILE}" | tee -a "${RESULT_FILE}"
 }
 
 install() {

--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -170,22 +170,20 @@ install() {
 
 ! check_root && error_msg "You need to be root to run this script."
 create_out_dir "${OUTPUT}"
-# shellcheck disable=SC2164
-cd "${OUTPUT}"
 
 install
 
 if [ -d "${KSELFTEST_PATH}" ]; then
     echo "kselftests found on rootfs"
-    # shellcheck disable=SC2164
-    cd "${KSELFTEST_PATH}"
+    # shellcheck disable=SC3044
+    pushd "${KSELFTEST_PATH}" || exit
 else
     # Fetch whatever we have been aimed at, assuming only that it can
     # be handled by "tar". Do not assume anything about the compression.
     wget "${TESTPROG_URL}"
     tar -xaf "$(basename "${TESTPROG_URL}")"
-    # shellcheck disable=SC2164
-    if [ ! -e "run_kselftest.sh" ]; then cd "kselftest"; fi
+    # shellcheck disable=SC3044
+    if [ ! -e "run_kselftest.sh" ]; then pushd "kselftest" || exit; fi
 fi
 
 skips=$(mktemp -p . -t skip-XXXXXX)
@@ -235,4 +233,6 @@ elif [ -n "${TST_CMDFILES}" ]; then
 else
     ./run_kselftest.sh 2>&1 | tee "${LOGFILE}"
 fi
+# shellcheck disable=SC3044
+popd || exit
 parse_output

--- a/automated/linux/kselftest/parse-output.py
+++ b/automated/linux/kselftest/parse-output.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import sys
+import re
+
+
+def slugify(line):
+    non_ascii_pattern = r"[^A-Za-z0-9_-]+"
+    line = re.sub(r"\[\d{1,5}\]", "", line)
+    return re.sub(
+        r"_-", "_", re.sub(r"(^_|_$)", "", re.sub(non_ascii_pattern, "_", line))
+    )
+
+
+tests = ""
+for line in sys.stdin:
+    if "# selftests: " in line:
+        tests = slugify(line.replace("\n", "").split("selftests:")[1])
+    elif re.search(r"^.*?not ok \d{1,5} ", line):
+        match = re.match(r"^.*?not ok (.*?)$", line)
+        ascii_test_line = slugify(re.sub("# .*$", "", match.group(1)))
+        if f"selftests_{tests}" in output:
+            output = re.sub(r"^.*_selftests_", "", output)
+        print(f"{output}")
+    elif re.search(r"^.*?ok \d{1,5} ", line):
+        match = re.match(r"^.*?ok (.*?)$", line)
+        if "# SKIP" in match.group(1):
+            ascii_test_line = slugify(re.sub("# SKIP", "", match.group(1)))
+            output = f"{tests}_{ascii_test_line} skip"
+        else:
+            ascii_test_line = slugify(match.group(1))
+            output = f"{tests}_{ascii_test_line} pass"
+        if f"selftests_{tests}" in output:
+            output = re.sub(r"^.*_selftests_", "", output)
+        print(f"{output}")


### PR DESCRIPTION
Update to use the same parser that 'kunit' uses.

Since there are a lot of subtests in kselftest that produce the same output like 'clone3 438_result_22_matches_expectation_22' thats why the subtest number are included into the test name.
The subsuite tests in 'kunit' are uniq, thats why we don't need to include the subtest number.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>