### PR TITLE
automated: kselftest: remove pushd/popd in favor for cd

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -148,15 +148,15 @@ install
 
 if [ -d "${KSELFTEST_PATH}" ]; then
     echo "kselftests found on rootfs"
-    # shellcheck disable=SC3044
-    pushd "${KSELFTEST_PATH}" || exit
+    # shellcheck disable=SC2164
+    cd "${KSELFTEST_PATH}" || exit
 else
     # Fetch whatever we have been aimed at, assuming only that it can
     # be handled by "tar". Do not assume anything about the compression.
     wget "${TESTPROG_URL}"
     tar -xaf "$(basename "${TESTPROG_URL}")"
     # shellcheck disable=SC3044
-    if [ ! -e "run_kselftest.sh" ]; then pushd "kselftest" || exit; fi
+    if [ ! -e "run_kselftest.sh" ]; then cd "kselftest" || exit; fi
 fi
 
 skips=$(mktemp -p . -t skip-XXXXXX)
@@ -206,6 +206,6 @@ elif [ -n "${TST_CMDFILES}" ]; then
 else
     ./run_kselftest.sh 2>&1 | tee "${LOGFILE}"
 fi
-# shellcheck disable=SC3044
-popd || exit
+# shellcheck disable=SC2164
+cd - || exit
 parse_output


### PR DESCRIPTION
pushd is a bash enhancement to the POSIX-specified Bourne Shell. Use 'cd' instead.

Signed-off-by: Anders Roxell <anders.roxell@linaro.org>