### PR TITLE
automated: kselftest: parse-output: fix fail cases

### DIFF
--- a/automated/linux/kselftest/parse-output.py
+++ b/automated/linux/kselftest/parse-output.py
@@ -18,6 +18,7 @@ for line in sys.stdin:
     elif re.search(r"^.*?not ok \d{1,5} ", line):
         match = re.match(r"^.*?not ok (.*?)$", line)
         ascii_test_line = slugify(re.sub("# .*$", "", match.group(1)))
+        output = f"{tests}_{ascii_test_line} fail"
         if f"selftests_{tests}" in output:
             output = re.sub(r"^.*_selftests_", "", output)
         print(f"{output}")


### PR DESCRIPTION
Forgot to set the fail output before removing the extra '_selftests_' from the output.

Fixes: 65be76866f2d ("automated: kselftest: update parser")
Reported-by: Naresh Kamboju <naresh.kamboju@linaro.org>
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>