### PR TITLE
Fix small parser issues

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -142,6 +142,7 @@ install() {
 }
 
 ! check_root && error_msg "You need to be root to run this script."
+saved_pwd=$(pwd)
 create_out_dir "${OUTPUT}"
 
 install
@@ -207,5 +208,5 @@ else
     ./run_kselftest.sh 2>&1 | tee "${LOGFILE}"
 fi
 # shellcheck disable=SC2164
-cd - || exit
+cd "$saved_pwd" || exit
 parse_output

--- a/automated/linux/kselftest/parse-output.py
+++ b/automated/linux/kselftest/parse-output.py
@@ -18,6 +18,7 @@ for line in sys.stdin:
     elif re.search(r"^.*?not ok \d{1,5} ", line):
         match = re.match(r"^.*?not ok (.*?)$", line)
         ascii_test_line = slugify(re.sub("# .*$", "", match.group(1)))
+        output = f"{tests}_{ascii_test_line} fail"
         if f"selftests_{tests}" in output:
             output = re.sub(r"^.*_selftests_", "", output)
         print(f"{output}")


### PR DESCRIPTION
After upgrading perl parser to python few small issues was discovered. One of them is failure to parse "not ok" result, another one is likely https://github.com/Linaro/test-definitions/pull/418 require more proper fix in some conditions.
Both commits tested on staging in kernelci and collabora LAVA: https://lava.collabora.dev/scheduler/job/8642420