### PR TITLE
automated: kselftest: Don't include test numbers for nested suites

### DIFF
--- a/automated/linux/kselftest/parse-output.py
+++ b/automated/linux/kselftest/parse-output.py
@@ -16,14 +16,14 @@ for line in sys.stdin:
     if "# selftests: " in line:
         tests = slugify(line.replace("\n", "").split("selftests:")[1])
     elif re.search(r"^.*?not ok \d{1,5} ", line):
-        match = re.match(r"^.*?not ok (.*?)$", line)
+        match = re.match(r"^.*?not ok [0-9]+ (.*?)$", line)
         ascii_test_line = slugify(re.sub("# .*$", "", match.group(1)))
         output = f"{tests}_{ascii_test_line} fail"
         if f"selftests_{tests}" in output:
             output = re.sub(r"^.*_selftests_", "", output)
         print(f"{output}")
     elif re.search(r"^.*?ok \d{1,5} ", line):
-        match = re.match(r"^.*?ok (.*?)$", line)
+        match = re.match(r"^.*?ok [0-9]+ (.*?)$", line)
         if "# SKIP" in match.group(1):
             ascii_test_line = slugify(re.sub("# SKIP", "", match.group(1)))
             output = f"{tests}_{ascii_test_line} skip"


### PR DESCRIPTION
When parsing results from tests produced from tests in nested test programs such as:

   # ok 1 getpid() FPSIMD

parse-output.py generates test names like:

   arm64_syscall-abi_1_getpid_FPSIMD pass

which include the test number. Since for programs using the kselftest framework the test number is allocated dynamically by the framework the test number is not really stable, meaning that including it in the test name can impede matching of results between test runs by systems. Instead discard this number and generate test names like:

   arm64_syscall-abi_getpid_FPSIMD

which will be stable as other tests are added and removed like those for top level suites.

Signed-off-by: Mark Brown <broonie@kernel.org>