### PR TITLE
kvm-unit-tests: Support preinstallation of kvm-unit-tests

### DIFF
--- a/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
+++ b/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
@@ -98,8 +98,12 @@ else
   install
 fi
 
-# Build kvm unit tests
-kvm_unit_tests_build_test
+# Build kvm unit tests if needed
+if [ -f /opt/kvm-unit-tests/run-tests.sh ]; then
+  cd /opt/kvm-unit-tests || exit 1
+else
+  kvm_unit_tests_build_test
+fi
 
 # Run kvm unit tests
 kvm_unit_tests_run_test


### PR DESCRIPTION
Rather than requiring kvm-unit-tests be built for every test run support using a preinstalled copy.

Signed-off-by: Mark Brown <broonie@kernel.org>