### PR TITLE
Revert "kselftest: skipfile-lkft: Adding arm64 fp-stress to skipfile"

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -402,11 +402,3 @@ skiplist:
     branches: all
     tests:
       - net:tls
-  - reason: >
-      arm64 fp-stress hangs on qemu devices
-    url: https://linaro.atlassian.net/browse/LKQ-1087
-    environments: all
-    boards: qemu_arm64
-    branches: all
-    tests:
-      - arm64:fp-stress


### PR DESCRIPTION
LKFT test farm noticed that fp-stress test is getting pass on
latest Qemu version 7.2.  Now fp-stress should be unskipped.
 
This reverts commit c61b8f17cf95547ae34d5bab1d9cd9375965885c.