### PR TITLE
mkdocs_plugin: testdefinitionsmkdocs: fix black warning

### DIFF
--- a/mkdocs_plugin/testdefinitionsmkdocs/__init__.py
+++ b/mkdocs_plugin/testdefinitionsmkdocs/__init__.py
@@ -10,7 +10,6 @@ from mdutils.fileutils.fileutils import MarkDownFile
 
 
 class LinaroTestDefinitionsMkDocsPlugin(BasePlugin):
-
     config_scheme = (
         ("table_file", Type(str, default="tests_table")),
         ("table_dirs", Type(list, default=["automated", "manual"])),


### PR DESCRIPTION
Black release 22.12.0 didn't complain. But now with black release 23.1.0, black enforce empty lines before classes and functions with sticky leading comments.

Link: https://black.readthedocs.io/en/stable/change_log.html#id1
Signed-off-by: Anders Roxell <anders.roxell@linaro.org>