### PR TITLE
kvm-unit-tests: Clarify logging for SKIP_INSTALL

### DIFF
--- a/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
+++ b/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
@@ -92,7 +92,7 @@ info_msg "Output directory: ${OUTPUT}"
 
 
 if [ "${SKIP_INSTALL}" = "True" ] || [ "${SKIP_INSTALL}" = "true" ]; then
-    info_msg "kvm-unit-tests skipped"
+    info_msg "Dependency installation for kvm-unit-tests skipped"
 else
   # Install packages
   install


### PR DESCRIPTION
Currently the log message we print when we skip installing dependencies
looks very much like it's skipping the tests themselves.  Clarify what
is happening.
