### PR TITLE
kvm-unit-tests: Fix naming of run_tests.sh

### DIFF
--- a/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
+++ b/automated/linux/kvm-unit-tests/kvm-unit-tests.sh
@@ -99,7 +99,7 @@ else
 fi
 
 # Build kvm unit tests if needed
-if [ -f /opt/kvm-unit-tests/run-tests.sh ]; then
+if [ -f /opt/kvm-unit-tests/run_tests.sh ]; then
   cd /opt/kvm-unit-tests || exit 1
 else
   kvm_unit_tests_build_test


### PR DESCRIPTION
The script is checking for run-tests.sh when looking to see if we have a
preinstalled copy of the tests but the script that the tests install is
run_tests.sh with an _ not a -.  Fix that.
