### PR TITLE
kselftest: Run the ftrace tests

### DIFF
--- a/automated/linux/kselftest/skipfile-lkft.yaml
+++ b/automated/linux/kselftest/skipfile-lkft.yaml
@@ -20,17 +20,6 @@
 
 skiplist:
 
-  - reason: >
-      LKFT: linux-next: x15: kselftest: ftracetest hangs forever
-      LKFT: linux-mainline: kernel panic on X15 when running ftrace kseltest
-      https://bugs.linaro.org/show_bug.cgi?id=3304
-    url: https://bugs.linaro.org/show_bug.cgi?id=3297
-    environments: all
-    boards: all
-    branches: all
-    tests:
-      - ftrace:ftracetest
-
   - reason: "LKFT: linux-next: kselftest: breakpoint_test_arm64 build failed"
     url: https://bugs.linaro.org/show_bug.cgi?id=3208
     environments: all


### PR DESCRIPTION
The ftrace tests are currently skipped with references to some kernel
bugs from back in 2017.  Given that developers use these tests regularly
without seeing problems and the age of the bugs it seems likely that
they are no longer relevant, testing seems to indicate that's the case
for at least arm64.  Remove the skip.

Signed-off-by: Mark Brown <broonie@kernel.org>
