### PR TITLE
automated: linux: add se05x reset after running xtest

### DIFF
--- a/automated/linux/optee/optee-xtest.sh
+++ b/automated/linux/optee/optee-xtest.sh
@@ -5,16 +5,18 @@ OUTPUT="$(pwd)/output"
 RESULT_FILE="${OUTPUT}/result.txt"
 TEST_LEVEL="0"
 TEST_SUITE="regression"
+SE05X_TOOL=""
 
 usage() {
-    echo "Usage: $0 [-l <0-15> -t <regression|benchmark>]" 1>&2
+    echo "Usage: $0 [-l <0-15>] [-t <regression|benchmark>] [-s <se050-tool>]" 1>&2
     exit 1
 }
 
-while getopts "l:t:h:" o; do
+while getopts "l:t:s:h:" o; do
   case "$o" in
     l) TEST_LEVEL="${OPTARG}" ;;
     t) TEST_SUITE="${OPTARG}" ;;
+    s) SE05X_TOOL="${OPTARG}" ;;
     h|*) usage ;;
   esac
 done
@@ -55,3 +57,11 @@ grep -E "^[0-9]+ test case was skipped" "${LOG_FILE}" \
 
 # Cleanup.
 kill "${tee_supplicant_pid}" || true
+# remove temporary SE050 objects
+if [ "${SE05X_TOOL}" = "ssscli" ]; then
+    ssscli connect se05x t1oi2c none
+    ssscli se05x reset
+fi
+if [ "${SE05X_TOOL}" = "fio-se05x-cli" ]; then
+    fio-se05x-cli --delete-objects --se050
+fi

--- a/automated/linux/optee/optee-xtest.yaml
+++ b/automated/linux/optee/optee-xtest.yaml
@@ -19,9 +19,11 @@ params:
     TEST_LEVEL: "0"
     # Available test suite: regression, benchmark
     TEST_SUITE: "regression"
+    # SE05X tool
+    SE05X_TOOL: ""
 
 run:
     steps:
         - cd ./automated/linux/optee/
-        - ./optee-xtest.sh -l "${TEST_LEVEL}" -t "${TEST_SUITE}"
+        - ./optee-xtest.sh -l "${TEST_LEVEL}" -t "${TEST_SUITE}" -s "${SE05X_TOOL}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
When running xtest on the device with secure element (SE050) some tests generate objects in the element. These objects are not deleted by the tests:
https://github.com/OP-TEE/optee_test/issues/652
In the long run secure element runs out of space and all tests start failing with strange errors. To mitigate this the script will call reset method on SE050 after all tests are completed. This should at least fix the problem of residual objects.