### PR TITLE
noninteractive-tradefed: add ping test

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -12,6 +12,10 @@ TEST_PARAMS="cts -m CtsBionicTestCases --abi arm64-v8a --disable-reboot --skip-p
 TEST_PATH="android-cts"
 RESULT_FORMAT="aggregated"
 RESULT_FILE="$(pwd)/output/result.txt"
+DIR_RESULT_FILE="$(pwd)/output"
+# create the directory for ${RESULT_FILE}
+# so that report_pass and report_fail would work
+mkdir -p "${DIR_RESULT_FILE}"
 export RESULT_FILE
 # the default number of failed test cases to be printed
 FAILURES_PRINTED="0"
@@ -85,6 +89,19 @@ else
     # https://github.com/steinwurf/adb-join-wifi
     # if AP_SSID and AP_KEY are not specified for this tradefed test action
     adb_join_wifi "${AP_SSID}" "${AP_KEY}"
+fi
+
+# wait for a while till the wifi connecting operation finished
+sleep 60
+
+SERVER="www.google.com"
+info_msg "device-${ANDROID_SERIAL}: About to check with ping ${SERVER}..."
+if adb shell 'ping -c 10 '"${SERVER}"'; echo exitcode: $?' | grep -q "exitcode: 0"; then
+    report_pass "network-available"
+else
+    report_fail "network-available"
+    # to be caught by the yaml file
+    exit 100
 fi
 
 # Run tradefed test.

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -57,7 +57,7 @@ run:
         - chown testuser:testuser .
         - if echo "${TEST_REBOOT_EXPECTED}" |grep -i "true" ; then ./monitor_fastboot.sh & fi
         - ./monitor_adb.sh &
-        - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}" || true
+        - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}" || if [ $? -eq 100 ]; then error_fatal "The network seems not available, as the ping to ${SERVER} failed"; else true; fi
         # Upload test log and result files to artifactorial.
         - cp -r ./${TEST_PATH}/results ./output/ || true
         - cp -r ./${TEST_PATH}/logs ./output/ || true


### PR DESCRIPTION
to report network failures early.
Tested with the following jobs:
https://validation.linaro.org/scheduler/job/3939143: network enabled on the DUT side after wifi setup
https://validation.linaro.org/scheduler/job/3939144: network not available on the DUT side
https://lkft.validation.linaro.org/scheduler/job/6300769: network available with the default ethernet cable 