### PR TITLE
noninteractive-tradefed: support to use lkft-cache for cache

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -62,12 +62,12 @@ disable_suspend
 # wait_homescreen "${TIMEOUT}"
 
 # Download CTS/VTS test package or copy it from local disk.
-if echo "${TEST_URL}" | grep "^http" ; then
-    wget -S --progress=dot:giga "${TEST_URL}"
-else
-    cp "${TEST_URL}" ./
-fi
 file_name=$(basename "${TEST_URL}")
+if echo "${TEST_URL}" | grep "^http" ; then
+    wget -S --progress=dot:giga "${TEST_URL}" -O "${file_name}"
+else
+    cp "${TEST_URL}" "./${file_name}"
+fi
 unzip -q "${file_name}"
 rm -f "${file_name}"
 

--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -63,7 +63,9 @@ disable_suspend
 
 # Download CTS/VTS test package or copy it from local disk.
 file_name=$(basename "${TEST_URL}")
-if echo "${TEST_URL}" | grep "^http" ; then
+if echo "${TEST_URL}" | grep "^http://lkft-cache.lkftlab/" ; then
+    NO_PROXY=.lkftlab wget -S --progress=dot:giga "${TEST_URL}" -O "${file_name}"
+elif echo "${TEST_URL}" | grep "^http" ; then
     wget -S --progress=dot:giga "${TEST_URL}" -O "${file_name}"
 else
     cp "${TEST_URL}" "./${file_name}"


### PR DESCRIPTION
only lkft-cache.lkftlab is supported with this PR, it should be more generic when another kisscache server is supported.