### PR TITLE
noninteractive-tradefed: run ping 8.8.8.8 for network failures

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -102,6 +102,7 @@ else
     report_fail "network-available"
     # print more debug information
     adb shell ip address
+    adb shell ping -c 10 8.8.8.8
     # to be caught by the yaml file
     exit 100
 fi


### PR DESCRIPTION
to make sure if the problem is with dns or something else