### PR TITLE
optee-xtest.yml: clear storage before executing tests

### DIFF
--- a/automated/linux/optee/optee-xtest.yaml
+++ b/automated/linux/optee/optee-xtest.yaml
@@ -25,5 +25,6 @@ params:
 run:
     steps:
         - cd ./automated/linux/optee/
+        - xtest --clear-storage || true
         - ./optee-xtest.sh -l "${TEST_LEVEL}" -t "${TEST_SUITE}" -s "${SE05X_TOOL}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Previously failed tests can leave some data in storage which fails the tests later on unless data is cleared. --clear-storage option is new to xtest:

https://github.com/OP-TEE/optee_test/pull/670

See also:

https://gitlab.com/Linaro/trustedsubstrate/meta-ledge-secure/-/merge_requests/60

Ignore return values since the option may not exist in all xtest versions and it can also report failures.