### PR TITLE
automated: linux: fix cleanup after xtest

### DIFF
--- a/automated/linux/optee/optee-xtest.sh
+++ b/automated/linux/optee/optee-xtest.sh
@@ -63,5 +63,5 @@ if [ "${SE05X_TOOL}" = "ssscli" ]; then
     ssscli se05x reset
 fi
 if [ "${SE05X_TOOL}" = "fio-se05x-cli" ]; then
-    fio-se05x-cli --delete-objects --se050
+    fio-se05x-cli --factory-reset --se050
 fi


### PR DESCRIPTION
When running xtest on a device with secure element (SE050) there are some objects left behind. This patch fixes the cleanup of the objects on LmP platform.