### PR TITLE
noninteractive-tradefed: drop check for ANDROID_VERSION

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -5,15 +5,8 @@
 . ../../lib/sh-test-lib
 . ../../lib/android-test-lib
 
-JDK="openjdk-8-jdk-headless"
-java_path="/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java"
-if [ -n "${ANDROID_VERSION}" ] && echo "${ANDROID_VERSION}" | grep -q  "aosp-master\|aosp-android11\|aosp-android12\|aosp-android13"; then
-    # only use openjdk-11 for aosp master version
-    JDK="openjdk-11-jdk-headless"
-    java_path="/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
-#elif 8.1/9.0/android10
-#   JDK="openjdk-8-jdk-headless"
-fi
+JDK="openjdk-11-jdk-headless"
+java_path="/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
 
 PKG_DEPS="coreutils usbutils curl wget zip xz-utils python-lxml python-setuptools python-pexpect aapt lib32z1-dev libc6-dev-i386 lib32gcc1 libc6:i386 libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 python-dev python-protobuf protobuf-compiler python-virtualenv python-pip python-pexpect psmisc"
 


### PR DESCRIPTION
since Android10 is deprecated, and OpenJDK11 could be used for all later versisons, here make it simple
to only use OpenJDK11 to avoid changes for different Android versions in the future