### PR TITLE
noninteractive-tradefed: install OpenJDK17 for Android14

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -7,6 +7,11 @@
 
 JDK="openjdk-11-jdk-headless"
 java_path="/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
+if [ -n "${ANDROID_VERSION}" ] && echo "${ANDROID_VERSION}" | grep -q  "aosp-android14"; then
+    # use openjdk-17 for Android14+ versions
+    JDK="openjdk-17-jdk-headless"
+    java_path="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
+fi
 
 PKG_DEPS="coreutils usbutils curl wget zip xz-utils python-lxml python-setuptools python-pexpect aapt lib32z1-dev libc6-dev-i386 lib32gcc1 libc6:i386 libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 python-dev python-protobuf protobuf-compiler python-virtualenv python-pip python-pexpect psmisc"
 


### PR DESCRIPTION
Otherwise there will be version not support problem reported when run the cts tests