### PR TITLE
kselftest: Adding new test case for sharding status

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -200,6 +200,12 @@ elif [ -n "${TST_CMDFILES}" ]; then
         echo "============== Tests to run ==============="
         cat shardfile
         echo "===========End Tests to run ==============="
+        if [ -s shardfile ]; then
+            report_pass "shardfile-${test}"
+        else
+            report_fail "shardfile-${test}"
+            continue
+        fi
         cp shardfile kselftest-list.txt
         ./run_kselftest.sh -c ${test} 2>&1 | tee -a "${LOGFILE}"
     done


### PR DESCRIPTION
Adding new test case to check sharding status.
When sharding file is empty, test will fail and exit.

Suggested-by:  Anders Roxell <anders.roxell@linaro.org>