### PR TITLE
noninteractive-tradefed: change to work with python3

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -5,22 +5,15 @@
 . ../../lib/sh-test-lib
 . ../../lib/android-test-lib
 
-JDK="openjdk-11-jdk-headless"
 java_path="/usr/lib/jvm/java-11-openjdk-amd64/bin/java"
 if [ -n "${ANDROID_VERSION}" ] && echo "${ANDROID_VERSION}" | grep -q  "aosp-android14"; then
     # use openjdk-17 for Android14+ versions
-    JDK="openjdk-17-jdk-headless"
     java_path="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"
 fi
-
-PKG_DEPS="coreutils usbutils curl wget zip xz-utils python-lxml python-setuptools python-pexpect aapt lib32z1-dev libc6-dev-i386 lib32gcc1 libc6:i386 libstdc++6:i386 libgcc1:i386 zlib1g:i386 libncurses5:i386 python-dev python-protobuf protobuf-compiler python-virtualenv python-pip python-pexpect psmisc"
 
 dist_name
 case "${dist}" in
     ubuntu)
-        dpkg --add-architecture i386
-        apt-get update -q
-        install_deps "${PKG_DEPS} ${JDK}"
         # make sure to use the right java version
         update-alternatives --set java ${java_path}
         ;;

--- a/automated/android/noninteractive-tradefed/tradefed-runner.py
+++ b/automated/android/noninteractive-tradefed/tradefed-runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import datetime
 import os
@@ -27,7 +27,7 @@ ATOMIC = "atomic"
 
 def result_parser(xml_file, result_format):
     etree_file = open(xml_file, "rb")
-    etree_content = etree_file.read()
+    etree_content = etree_file.read().decode("utf-8")
     rx = re.compile("&#([0-9]+);|&#x([0-9a-fA-F]+);")
     endpos = len(etree_content)
     pos = 0

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -14,7 +14,6 @@ metadata:
         - functional
 
 params:
-    SKIP_INSTALL: "false"
     # Specify timeout in seconds for wait_boot_completed and wait_homescreen.
     TIMEOUT: "300"
     # Download CTS package or copy it from local disk.


### PR DESCRIPTION
This commit change to use python3 for tradefed-runner.py,
and drop the packages installation as they will be installed
on the Ubuntu20.04 based docker image side which will have
python3 installed as the default python.

The background is that, the latest AOSP vts package needs to
have python3.8+ to run the vts_kernel_proc_file_api_test module
after the following commit:
    https://android.googlesource.com/platform/test/vts-testcase/vndk/+/6f09ccb69d553a48dd231635a06889af26ff545f%5E%21/#F3

Otherwise, the following error will be reported:
```
    07-26 12:45:26 I/ModuleListener: [66/67] cbe37e vts_kernel_proc_file_api_test __main__.VtsKernelProcFileApiTest#test_ProcZoneInfoTest FAILURE: Traceback (most recent call last):
      File "/tmp/Soong.python_p2c4wyvb/vts_kernel_proc_file_api_test.py", line 277, in test
        test_object.set_api_level(self.dut)
      File "/tmp/Soong.python_p2c4wyvb/proc_tests/KernelProcFileTestBase.py", line 140, in set_api_level
        self.api_level = dut.getLaunchApiLevel(strict=False)
      File "/tmp/Soong.python_p2c4wyvb/vts/testcases/vndk/utils.py", line 147, in getLaunchApiLevel
        return self.GetLaunchApiLevel()
      File "/tmp/Soong.python_p2c4wyvb/vts/testcases/vndk/utils.py", line 122, in GetLaunchApiLevel
        level_str = self._GetProp("ro.product.first_api_level")
      File "/tmp/Soong.python_p2c4wyvb/vts/testcases/vndk/utils.py", line 94, in _GetProp
        out, err, return_code = self.Execute("getprop", name)
      File "/tmp/Soong.python_p2c4wyvb/vts/testcases/vndk/utils.py", line 68, in Execute
        cmd = ["adb", "-s", self._serial_number, "shell", shlex.join(args)]
    AttributeError: module 'shlex' has no attribute 'join'
```