### PR TITLE
automated: linux: rcutorture: drop config checking

### DIFF
--- a/automated/linux/rcutorture/rcutorture.sh
+++ b/automated/linux/rcutorture/rcutorture.sh
@@ -47,7 +47,7 @@ if lsmod | grep rcutorture; then
 fi
 test_cmd="modprobe rcutorture"
 tc_id="modprobe-rcutorture"
-skip_list="rctorture-start rmmod-rcutorture rcutorture-end"
+skip_list="rcutorture-start rmmod-rcutorture rcutorture-end"
 run_test_case "${test_cmd}" "${tc_id}" "${skip_list}"
 
 # Check if rcutoruture started.

--- a/automated/linux/rcutorture/rcutorture.sh
+++ b/automated/linux/rcutorture/rcutorture.sh
@@ -28,18 +28,6 @@ done
 install_deps "gzip" "${SKIP_INSTALL}"
 create_out_dir "${OUTPUT}"
 
-# Check kernel config.
-if [ -f "/proc/config.gz" ]; then
-    test_cmd="gunzip -c /proc/config.gz | grep CONFIG_RCU_TORTURE_TEST=m"
-elif [ -f "/boot/config-$(uname -r)" ]; then
-    test_cmd="grep CONFIG_RCU_TORTURE_TEST=m /boot/config-$(uname -r)"
-fi
-if [ -n "${test_cmd}" ]; then
-    tc_id="check-kernel-config"
-    skip_list="modprobe-rcutorture rctorture-start rmmod-rcutorture rcutorture-end"
-    run_test_case "${test_cmd}" "${tc_id}" "${skip_list}"
-fi
-
 # Insert rcutoruture kernel module.
 dmesg -c > /dev/null
 if lsmod | grep rcutorture; then

--- a/automated/linux/rcutorture/rcutorture.sh
+++ b/automated/linux/rcutorture/rcutorture.sh
@@ -5,17 +5,15 @@ OUTPUT="${TEST_DIR}/output"
 RESULT_FILE="${OUTPUT}/result.txt"
 export RESULT_FILE
 LOGFILE="${OUTPUT}/dmesg-rcutorture.txt"
-SKIP_INSTALL="false"
 TORTURE_TIME="600"
 
 usage() {
-    echo "Usage: $0 [-s <skip_install>] [-t <rcutorture_time>]" 1>&2
+    echo "Usage: $0 [-t <rcutorture_time>]" 1>&2
     exit 1
 }
 
-while getopts ':s:t:' opt; do
+while getopts ':t:' opt; do
     case "${opt}" in
-        s) SKIP_INSTALL="${OPTARG}" ;;
         t) TORTURE_TIME="${OPTARG}" ;;
         *) usage ;;
     esac
@@ -25,7 +23,6 @@ done
 . "${TEST_DIR}/../../lib/sh-test-lib"
 
 ! check_root && error_msg "Please run this script as root."
-install_deps "gzip" "${SKIP_INSTALL}"
 create_out_dir "${OUTPUT}"
 
 # Insert rcutoruture kernel module.

--- a/automated/linux/rcutorture/rcutorture.yaml
+++ b/automated/linux/rcutorture/rcutorture.yaml
@@ -27,11 +27,10 @@ metadata:
         - functional
 
 params:
-    SKIP_INSTALL: "false"
     TORTURE_TIME: 600
 
 run:
     steps:
         - cd automated/linux/rcutorture
-        - ./rcutorture.sh -s "${SKIP_INSTALL}" -t "${TORTURE_TIME}"
+        - ./rcutorture.sh -t "${TORTURE_TIME}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
No need to check for fragments since it can be built into the kernel and then run on boot.