### PR TITLE
apk-automation: install and use python3.9

### DIFF
--- a/automated/android/apk-automation/apk-automation.sh
+++ b/automated/android/apk-automation/apk-automation.sh
@@ -42,7 +42,7 @@ if [ "${SKIP_INSTALL}" = "true" ] || [ "${SKIP_INSTALL}" = "True" ]; then
 else
     ! check_root && error_msg "Please run this script as superuser!"
     #install_deps "git python python-lxml python-pil python-setuptools python-requests python-matplotlib python-requests ca-certificates curl tar xz-utils" "${SKIP_INSTALL}"
-    install_deps "python3-distutils git ca-certificates curl tar xz-utils" "${SKIP_INSTALL}"
+    install_deps "python3.9 python3-distutils git ca-certificates curl tar xz-utils" "${SKIP_INSTALL}"
     if python3 --version|grep 'Python 3.6'; then
         # Workaround for Ubuntu 18.04 Bionic version.
         # ModuleNotFoundError: No module named 'distutils.cmd' needs python3-distutils
@@ -58,7 +58,7 @@ else
     sudo pip install virtualenv
     pip --version
     virenv_dir=python-workspace
-    virtualenv --python=python3 ${virenv_dir}
+    virtualenv --python=python3.9 ${virenv_dir}
     [ ! -d AndroidViewClient ]  && git clone --depth 1 "${url_android_view_clien}"
     # shellcheck disable=SC1090
     source ${virenv_dir}/bin/activate


### PR DESCRIPTION
as numpy 1.25.1 requires 3.9+ python.

    Reading https://pypi.org/simple/numpy/
    Downloading https://files.pythonhosted.org/packages/cf/7a/f68d1d658a0e68084097beb212fa9356fee7eabff8b57231cc4acb555b12/numpy-1.25.1.tar.gz#sha256=9a3a9f3a61480cc086117b426a8bd86869c213fc4072e606f01c4e4b66eb92bf
    Best match: numpy 1.25.1
    Processing numpy-1.25.1.tar.gz
    Writing /tmp/easy_install-8zhunwcp/numpy-1.25.1/setup.cfg
    Running numpy-1.25.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-8zhunwcp/numpy-1.25.1/egg-dist-tmp-8s2br4p6
    Traceback (most recent call last):
      File "/linaro-android/test/python-workspace/lib/python3.8/site-packages/setuptools/sandbox.py", line 156, in save_modules
        yield saved
      File "/linaro-android/test/python-workspace/lib/python3.8/site-packages/setuptools/sandbox.py", line 198, in setup_context
        yield
      File "/linaro-android/test/python-workspace/lib/python3.8/site-packages/setuptools/sandbox.py", line 259, in run_setup
        _execfile(setup_script, ns)
      File "/linaro-android/test/python-workspace/lib/python3.8/site-packages/setuptools/sandbox.py", line 46, in _execfile
        exec(code, globals, locals)
      File "/tmp/easy_install-8zhunwcp/numpy-1.25.1/setup.py", line 22, in <module>
        classifiers=['Development Status :: 5 - Production/Stable',
    RuntimeError: Python version >= 3.9 required.