### PR TITLE
automated: linux: 24h-stress-test: fix git repository

### DIFF
--- a/automated/linux/24h-stress-test/24h-stress-test.sh
+++ b/automated/linux/24h-stress-test/24h-stress-test.sh
@@ -231,7 +231,7 @@ if ! which stress-ng; then
         case "${dist}" in
             debian|ubuntu)
                 install_deps "git build-essential libaio-dev libapparmor-dev libattr1-dev libbsd-dev libcap-dev libkeyutils-dev libsctp-dev zlib1g-dev"
-                git clone git://kernel.ubuntu.com/cking/stress-ng.git
+                git clone git://kernel.ubuntu.com/ubuntu/stress-ng.git
                 (
                     cd stress-ng || exit
                     # Use a known good release.


### PR DESCRIPTION
The repository is not found:

```shell
$ git clone git://kernel.ubuntu.com/cking/stress-ng.git
Klone nach 'stress-ng' …
fatal: Fehler am anderen Ende: no such repository: /cking/stress-ng.git
``` 

The test works after this change: 
```shell
$ git clone git://kernel.ubuntu.com/ubuntu/stress-ng.git
Klone nach 'stress-ng' …
remote: Counting objects: 41543, done.
remote: Compressing objects: 100% (9594/9594), done.
remote: Total 41543 (delta 32120), reused 41338 (delta 31915)
Empfange Objekte: 100% (41543/41543), 17.71 MiB | 12.17 MiB/s, fertig.
Löse Unterschiede auf: 100% (32120/32120), fertig.
``` 