### PR TITLE
automated: linux: ltp: skipfile: Skipfile reformat

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -24,7 +24,7 @@ skiplist:
     url: https://bugs.linaro.org/show_bug.cgi?id=3719
     environments: all
     boards:
-      - all 
+      - all
     branches: all
     tests:
       - fork13
@@ -36,7 +36,7 @@ skiplist:
     url: https://bugs.linaro.org/show_bug.cgi?id=2355
     environments: all
     boards:
-      - all 
+      - all
     branches: all
     tests:
       - msgctl10
@@ -50,7 +50,7 @@ skiplist:
     url: https://bugs.linaro.org/show_bug.cgi?id=3303
     environments: all
     boards:
-      - all 
+      - all
     branches:
       - 4.4
       - 4.9
@@ -104,7 +104,7 @@ skiplist:
     url: https://bugs.linaro.org/show_bug.cgi?id=3338
     environments: all
     boards:
-      - all 
+      - all
     branches: all
     tests:
       - pth_str01
@@ -142,19 +142,20 @@ skiplist:
     url: https://bugs.linaro.org/show_bug.cgi?id=3777
     environments: all
     boards:
-      - all 
+      - all
     branches: all
     tests:
       - hackbench01
       - hackbench02
 
   - reason: >
-      LKFT: linux-next: x86: LTP sendfile09 and sendfile09_64 failed: errno=EFBIG(27): File too large
+      LKFT: linux-next: x86: LTP sendfile09 and sendfile09_64 failed: errno=EFBIG(27):
+      File too large
       Test creates more than 3GB file which is time consuming so skipping.
     url: https://bugs.linaro.org/show_bug.cgi?id=3234
     environments: all
     boards:
-      - all 
+      - all
     branches:
       - all
     tests:


### PR DESCRIPTION
Clean up LTP skipfile formatting by removing unnecessary spaces and by limiting line length.

These changes will align the skipfile with the ruamel.yaml Python library's formatter, which I plan to use to for automating updates to the skipfile.