### PR TITLE
kunit: Add missing space for printed message

### DIFF
--- a/automated/linux/kunit/kunit.sh
+++ b/automated/linux/kunit/kunit.sh
@@ -91,7 +91,7 @@ then
     KERNEL_CONFIG_FILE="/boot/config-$(uname -r)"
     CONFIG_KUNIT_TEST=$(grep "CONFIG_KUNIT_TEST=" "${KERNEL_CONFIG_FILE}")
 else
-    info_msg"Kernel config file not available"
+    info_msg "Kernel config file not available"
 fi
 if [ "${CONFIG_KUNIT_TEST}" = "CONFIG_KUNIT_TEST=y" ]
 then


### PR DESCRIPTION
This fixes a problem when certain conditions are met:
```
./kunit.sh: line 94: info_msgKernel config file not available: command not found
```