### PR TITLE
noninteractive-tradefed: monitor_fastboot.sh: drop sleep

### DIFF
--- a/automated/android/noninteractive-tradefed/monitor_fastboot.sh
+++ b/automated/android/noninteractive-tradefed/monitor_fastboot.sh
@@ -17,5 +17,4 @@ do
         echo "No boot image found under /lava-lxc and /lava-downloads, please check and try again!"
         exit 1
     fi
-    sleep 30
 done


### PR DESCRIPTION
    so that it could try again after the fastboot failure
    case like reported here:
        https://linaro.atlassian.net/browse/STG-5007
    
    when the usb connection to the DUT is not stable
    
    and the wait will be done by the fastboot command
    until it finds the device is in fastboot mode again.