### PR TITLE
automated: linux: Add AWS IoT use case to el2go test

### DIFF
--- a/automated/linux/el2go/el2go.yaml
+++ b/automated/linux/el2go/el2go.yaml
@@ -6,7 +6,19 @@ metadata:
         FoundriesFactory. If the device is successfully
         registered, the test passes. Running the test requires
         FoundriesFactory with EL2GO integration and a device
-        with SE050 secure element."
+        with SE050 secure element.
+
+        Optionally AWS IoT integration can be tested by setting
+        AWS_ENDPOINT and AWS_CONTAINER variables. It is recommended
+        to use Foundries.io awsiot-optee container with corresponding
+        LmP release. The container sources can be found on github:
+        https://github.com/foundriesio/containers/tree/master/awsiot-optee
+
+        AWS_ENDPOINT is the URL returned by:
+        aws iot describe-endpoint --endpoint-type iot:Data-ATS --query 'endpointAddress' --output text
+
+        It is recommented to reset SE050 secure element after the test.
+        This is done by setting RESET_SE05X to True."
     maintainer:
         - milosz.wasilewski@foundries.io
     os:
@@ -18,11 +30,14 @@ metadata:
         - imx6ull
 
 params:
-    PTOOL: "pkcs11-tool --module /usr/lib/libckteec.so.0.1"
+    PTOOL: "pkcs11-tool --module /usr/lib/libckteec.so.0.1.0"
     SLOT_INIT: "False"
+    RESET_SE05X: "True"
+    AWS_ENDPOINT: ""
+    AWS_CONTAINER: ""
 
 run:
     steps:
         - cd ./automated/linux/el2go/
-        - ./el2go.sh -s "${SLOT_INIT}" -p "${PTOOL}"
+        - ./el2go.sh -s "${SLOT_INIT}" -p "${PTOOL}" -r "${RESET_SE05X}" -e "${AWS_ENDPOINT}" -c "${AWS_CONTAINER}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
This patch adds support for testing AWS IoT integration for EL2GO service with FoundriesFactory. More detailed instructions are available from the el2go.yaml