### PR TITLE
automated: linux: fix network-basic exit code

### DIFF
--- a/automated/linux/network-basic/network-basic.sh
+++ b/automated/linux/network-basic/network-basic.sh
@@ -94,3 +94,6 @@ run "${DHCLIENT} ${INTERFACE}" "Dynamic-Host-Configuration-Protocol-Client-dhcli
 run "route" "print-routing-tables-after-dhclient-request"
 run "ping -c 5 ${GATEWAY}" "ping-gateway"
 run "${CURL} ${OUTPUT}/curl_big_video.avi http://samplemedia.linaro.org/MPEG4/big_buck_bunny_480p_MPEG4_MP3_25fps_1600K_short.AVI" "download-a-file"
+
+# exit with return code 0 to help LAVA parse results
+exit 0


### PR DESCRIPTION
When last test in network-basic fails (download-a-file) the whole set of tests is lost because LAVA receives exit code 1 and ignores the whole network-basic suite. This patch adds "exit 0" to the end of the test script to avoid this issue.