### PR TITLE
lib: add u-boot related functions to sh-test-lib

### DIFF
--- a/automated/lib/sh-test-lib
+++ b/automated/lib/sh-test-lib
@@ -766,3 +766,39 @@ check_config() {
         check_return "config_value_${c}"
     done
 }
+
+# this function allows to use u-boot variables in
+# linux shell. It gets the value of variable using
+# UBOOT_VAR_TOOL. This should be set to fw_printenv
+# or a tool with a similar function
+uboot_variable_value() {
+    # shellcheck disable=SC2039
+    local var="$1"
+    result=$("${UBOOT_VAR_TOOL}" "${var}")
+    if [ -n "${result}" ]; then
+        echo "${result#*=}"
+    else
+        echo ""
+    fi
+}
+
+# this function compares values of 2 arguments
+# it reports pass if the arguments are identical
+compare_test_value() {
+    # shellcheck disable=SC2039
+    local test_name="$1"
+    # shellcheck disable=SC2039
+    local expected_value="$2"
+    # shellcheck disable=SC2039
+    local tested_value="$3"
+
+    echo "Testing: #${test_name}#"
+    echo "Expected: #${expected_value}#"
+    echo "Actual: #${tested_value}#"
+
+    if [ "${expected_value}" = "${tested_value}" ]; then
+        report_pass "${test_name}"
+    else
+        report_fail "${test_name}"
+    fi
+}


### PR DESCRIPTION
This patch adds 2 functions that deal with u-boot variables and variable comparison to sh-test-lib. These functions are used in ota-upgrade and ota-rollback tests.