### PR TITLE
automated: linux: Add offline update test

### DIFF
--- a/automated/linux/offline-update/offline-run.sh
+++ b/automated/linux/offline-update/offline-run.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023 Foundries.io Ltd.
+
+# shellcheck disable=SC1091
+. ./sh-lib
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+export RESULT_FILE
+TYPE="kernel"
+UBOOT_VAR_TOOL=fw_printenv
+export UBOOT_VAR_TOOL
+UBOOT_VAR_SET_TOOL=fw_setenv
+export UBOOT_VAR_SET_TOOL
+REF_TARGET_VERSION=""
+
+usage() {
+	echo "\
+     Usage: $0 [-t <kernel|uboot>] [-u <u-boot var read>] [-s <u-boot var set>] -r <reference version>
+
+    -t <kernel|uboot>
+        This determines type of upgrade test performed:
+        kernel: perform OTA upgrade without forcing firmware upgrade
+        uboot: force firmware upgrade
+    -u <u-boot variable read tool>
+        Set the name of the tool to read u-boot variables
+        On the unsecured systems it will usually be
+        fw_printenv. On secured systems it might be
+        fiovb_printenv
+    -s <u-boot variable set tool>
+        Set the name of the tool to set u-boot variables
+        On the unsecured systems it will usually be
+        fw_setenv. On secured systems it might be
+        fiovb_setenv
+    -r reference target version
+	"
+}
+
+while getopts "t:u:s:r:h" opts; do
+	case "$opts" in
+        t) TYPE="${OPTARG}";;
+        u) UBOOT_VAR_TOOL="${OPTARG}";;
+        s) UBOOT_VAR_SET_TOOL="${OPTARG}";;
+        r) REF_TARGET_VERSION="${OPTARG}";;
+        h|*) usage ; exit 1 ;;
+	esac
+done
+
+# the script works only on builds with aktualizr-lite
+# and lmp-device-auto-register
+
+! check_root && error_msg "You need to be root to run this script."
+create_out_dir "${OUTPUT}"
+
+aklite-offline run
+
+SECONDARY_BOOT_VAR_NAME="fiovb.is_secondary_boot"
+if [ "${UBOOT_VAR_TOOL}" != "fw_printenv" ]; then
+    SECONDARY_BOOT_VAR_NAME="is_secondary_boot"
+fi
+
+ref_bootcount_after_upgrade=0
+ref_rollback_after_upgrade=0
+ref_fiovb_is_secondary_boot_after_upgrade=0
+
+if [ "${TYPE}" = "uboot" ]; then
+    # boots to secondary slot. Set to 0 on a subsequent reboot
+    ref_fiovb_is_secondary_boot_after_upgrade=1
+    if [ "${BOOTROM_USE_SECONDARY}" = "false" ] || [ "${BOOTROM_USE_SECONDARY}" = "False" ]; then
+        ref_fiovb_is_secondary_boot_after_upgrade=0
+    fi
+    # set to 0 forcibly. It stays this way on the 1st reboot
+    ref_bootfirmware_version_after_upgrade=0
+else
+    . /usr/lib/firmware/version.txt
+    # shellcheck disable=SC2154
+    ref_bootfirmware_version_after_upgrade="${bootfirmware_version}"
+fi
+# check u-boot variables to ensure upgrade happend
+bootcount_after_upgrade=$(uboot_variable_value bootcount)
+compare_test_value "bootcount_after_upgrade" "${ref_bootcount_after_upgrade}" "${bootcount_after_upgrade}"
+rollback_after_upgrade=$(uboot_variable_value rollback)
+compare_test_value "rollback_after_upgrade" "${ref_rollback_after_upgrade}" "${rollback_after_upgrade}"
+bootfirmware_version_after_upgrade=$(uboot_variable_value bootfirmware_version)
+compare_test_value "bootfirmware_version_after_upgrade" "${ref_bootfirmware_version_after_upgrade}" "${bootfirmware_version_after_upgrade}"
+fiovb_is_secondary_boot_after_upgrade=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
+compare_test_value "fiovb_is_secondary_boot_after_upgrade" "${ref_fiovb_is_secondary_boot_after_upgrade}" "${fiovb_is_secondary_boot_after_upgrade}"
+
+. /etc/os-release
+# shellcheck disable=SC2154
+compare_test_value "target_version_after_upgrade" "${REF_TARGET_VERSION}" "${IMAGE_VERSION}"
+cat /etc/os-release
+cat /boot/loader/uEnv.txt

--- a/automated/linux/offline-update/offline-run.yaml
+++ b/automated/linux/offline-update/offline-run.yaml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023 Foundries.io
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: offline-run
+    description: "Perform 2nd part of offline-update with aklite-offline"
+
+    maintainer:
+        - milosz.wasilewski@foundries.io
+    os:
+        - openembedded
+    scope:
+        - functional
+
+    devices:
+        - imx8mm
+        - imx6ull
+
+params:
+        UBOOT_VAR_TOOL: "fw_printenv"
+        UBOOT_VAR_SET_TOOL: "fw_setenv"
+        TYPE: "kernel"
+        REF_TARGET_VERSION: ""
+run:
+    steps:
+        - cd ./automated/linux/offline-update
+        - ./offline-run.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -r "${REF_TARGET_VERSION}"
+        - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/offline-update/offline-update.sh
+++ b/automated/linux/offline-update/offline-update.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023 Foundries.io Ltd.
+
+# shellcheck disable=SC1091
+. ./sh-lib
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+export RESULT_FILE
+TYPE="kernel"
+UBOOT_VAR_TOOL=fw_printenv
+export UBOOT_VAR_TOOL
+UBOOT_VAR_SET_TOOL=fw_setenv
+export UBOOT_VAR_SET_TOOL
+PACMAN_TYPE="ostree+compose_apps"
+OFFLINE_UPDATE_DRIVE=""
+
+usage() {
+	echo "\
+     Usage: $0 -w <offline update dir> [-t <kernel|uboot>] [-u <u-boot var read>] [-s <u-boot var set>] [-o <ostree|ostree+compose_apps>]
+
+    -t <kernel|uboot>
+        This determines type of upgrade test performed:
+        kernel: perform OTA upgrade without forcing firmware upgrade
+        uboot: force firmware upgrade
+    -u <u-boot variable read tool>
+        Set the name of the tool to read u-boot variables
+        On the unsecured systems it will usually be
+        fw_printenv. On secured systems it might be
+        fiovb_printenv
+    -s <u-boot variable set tool>
+        Set the name of the tool to set u-boot variables
+        On the unsecured systems it will usually be
+        fw_setenv. On secured systems it might be
+        fiovb_setenv
+    -o ostree or ostree+compose_apps update
+        These change the 'type' variable in 'pacman' section
+        of the final .toml file used by aklite. Default is
+        ostree+compose_apps
+    -w offline update directory
+	"
+}
+
+while getopts "t:u:s:o:w:h" opts; do
+	case "$opts" in
+        t) TYPE="${OPTARG}";;
+        u) UBOOT_VAR_TOOL="${OPTARG}";;
+        s) UBOOT_VAR_SET_TOOL="${OPTARG}";;
+        o) PACMAN_TYPE="${OPTARG}";;
+        w) OFFLINE_UPDATE_DRIVE="${OPTARG}";;
+        h|*) usage ; exit 1 ;;
+	esac
+done
+
+# the script works only on builds with aktualizr-lite
+# and lmp-device-auto-register
+
+! check_root && error_msg "You need to be root to run this script."
+create_out_dir "${OUTPUT}"
+
+if [ -z "${OFFLINE_UPDATE_DRIVE}" ]; then
+    echo "Offline update directory missing"
+    exit 1
+fi
+
+mkdir -p /etc/sota/conf.d
+if [ "${PACMAN_TYPE}" = "ostree" ]; then
+    cp z-99-aklite-callback-ostree.toml /etc/sota/conf.d/
+else
+    cp z-99-aklite-callback.toml /etc/sota/conf.d/
+fi
+
+SECONDARY_BOOT_VAR_NAME="fiovb.is_secondary_boot"
+if [ "${UBOOT_VAR_TOOL}" != "fw_printenv" ]; then
+    SECONDARY_BOOT_VAR_NAME="is_secondary_boot"
+fi
+
+ref_bootcount_before_upgrade=0
+ref_rollback_before_upgrade=0
+ref_fiovb_is_secondary_boot_before_upgrade=0
+ref_bootcount_after_upgrade=0
+ref_rollback_after_upgrade=0
+ref_fiovb_is_secondary_boot_after_upgrade=0
+
+# u-boot variables change when aklite starts (at least on some devices)
+# check u-boot variables to ensure we're on freshly flashed device
+bootcount_before_upgrade=$(uboot_variable_value bootcount)
+compare_test_value "${TYPE}_bootcount_before_upgrade" "${ref_bootcount_before_upgrade}" "${bootcount_before_upgrade}"
+rollback_before_upgrade=$(uboot_variable_value rollback)
+compare_test_value "${TYPE}_rollback_before_upgrade" "${ref_rollback_before_upgrade}" "${rollback_before_upgrade}"
+
+if [ -f /usr/lib/firmware/version.txt ]; then
+    # boot firmware is upgreadable
+    . /usr/lib/firmware/version.txt
+    bootfirmware_version_before_upgrade=$(uboot_variable_value bootfirmware_version)
+    # shellcheck disable=SC2154
+    compare_test_value "${TYPE}_bootfirmware_version_before_upgrade" "${bootfirmware_version}" "${bootfirmware_version_before_upgrade}"
+    fiovb_is_secondary_boot_before_upgrade=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
+    compare_test_value "${TYPE}_fiovb_is_secondary_boot_before_upgrade" "${ref_fiovb_is_secondary_boot_before_upgrade}" "${fiovb_is_secondary_boot_before_upgrade}"
+else
+    report_skip "${TYPE}_bootfirmware_version_before_upgrade"
+    report_skip "${TYPE}_fiovb_is_secondary_boot_before_upgrade"
+fi
+
+if [ "${TYPE}" = "uboot" ]; then
+    # manually set boot firmware version to 0
+    "${UBOOT_VAR_SET_TOOL}" bootfirmware_version 0
+fi
+
+mount "${OFFLINE_UPDATE_DRIVE}" /mnt
+aklite-offline install --log-level 1 --src-dir /mnt
+
+# check variables after download is completed
+bootcount_after_upgrade=$(uboot_variable_value bootcount)
+compare_test_value "${TYPE}_bootcount_after_upgrade" "${ref_bootcount_after_upgrade}" "${bootcount_after_upgrade}"
+rollback_after_upgrade=$(uboot_variable_value rollback)
+compare_test_value "${TYPE}_rollback_after_upgrade" "${ref_rollback_after_upgrade}" "${rollback_after_upgrade}"
+if [ -f /usr/lib/firmware/version.txt ]; then
+    . /usr/lib/firmware/version.txt
+    # shellcheck disable=SC2154
+    ref_bootfirmware_version_after_upgrade="${bootfirmware_version}"
+    if [ "${TYPE}" = "uboot" ]; then
+        ref_bootfirmware_version_after_upgrade=0
+    fi
+    bootfirmware_version_after_upgrade=$(uboot_variable_value bootfirmware_version)
+    # shellcheck disable=SC2154
+    compare_test_value "${TYPE}_bootfirmware_version_after_upgrade" "${ref_bootfirmware_version_after_upgrade}" "${bootfirmware_version_after_upgrade}"
+    fiovb_is_secondary_boot_after_upgrade=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
+    compare_test_value "${TYPE}_fiovb_is_secondary_boot_after_upgrade" "${ref_fiovb_is_secondary_boot_after_upgrade}" "${fiovb_is_secondary_boot_after_upgrade}"
+else
+    report_skip "${TYPE}_bootfirmware_version_after_upgrade"
+    report_skip "${TYPE}_fiovb_is_secondary_boot_after_upgrade"
+fi

--- a/automated/linux/offline-update/offline-update.yaml
+++ b/automated/linux/offline-update/offline-update.yaml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (C) 2023 Foundries.io
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: offline-update
+    description: "Perform 1st part of offline-update with aklite-offline"
+
+    maintainer:
+        - milosz.wasilewski@foundries.io
+    os:
+        - openembedded
+    scope:
+        - functional
+
+    devices:
+        - imx8mm
+        - imx6ull
+
+params:
+        UBOOT_VAR_TOOL: "fw_printenv"
+        UBOOT_VAR_SET_TOOL: "fw_setenv"
+        TYPE: "kernel"
+        PACMAN_TYPE: "ostree+compose_apps"
+        OFFLINE_UPDATE_DIR: "/dev/sda1"
+run:
+    steps:
+        - cd ./automated/linux/offline-update
+        - ./offline-update.sh -w "${OFFLINE_UPDATE_DIR}" -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}"
+        - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/offline-update/sh-lib
+++ b/automated/linux/offline-update/sh-lib
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+. ../../lib/sh-test-lib
+
+uboot_variable_value() {
+    # shellcheck disable=SC2039
+    local var="$1"
+    result=$("${UBOOT_VAR_TOOL}" "${var}")
+    if [ -n "${result}" ]; then
+        echo "${result#*=}"
+    else
+        echo ""
+    fi
+}
+
+compare_test_value() {
+    # shellcheck disable=SC2039
+    local test_name="$1"
+    # shellcheck disable=SC2039
+    local expected_value="$2"
+    # shellcheck disable=SC2039
+    local tested_value="$3"
+
+    echo "Testing: #${test_name}#"
+    echo "Expected: #${expected_value}#"
+    echo "Actual: #${tested_value}#"
+
+    if [ "${expected_value}" = "${tested_value}" ]; then
+        report_pass "${test_name}"
+    else
+        report_fail "${test_name}"
+    fi
+}

--- a/automated/linux/offline-update/z-99-aklite-callback-ostree.toml
+++ b/automated/linux/offline-update/z-99-aklite-callback-ostree.toml
@@ -1,0 +1,5 @@
+[pacman]
+type = "ostree"
+[bootloader]
+reboot_command = "/bin/true"
+

--- a/automated/linux/offline-update/z-99-aklite-callback.toml
+++ b/automated/linux/offline-update/z-99-aklite-callback.toml
@@ -1,0 +1,3 @@
+[bootloader]
+reboot_command = "/bin/true"
+


### PR DESCRIPTION
Offline update is a feature of LmP enabling update of devices that are offline most of the time.