### PR TITLE
automated: linux: OTA upgrade u-boot variable persistence

### DIFF
--- a/automated/linux/ota-update/download-update.yaml
+++ b/automated/linux/ota-update/download-update.yaml
@@ -22,8 +22,10 @@ params:
         UBOOT_VAR_SET_TOOL: "fw_setenv"
         TYPE: "kernel"
         PACMAN_TYPE: "ostree+compose_apps"
+        UBOOT_VARIABLE_NAME: "foobar"
+        UBOOT_VARIABLE_VALUE: "baz"
 run:
     steps:
         - cd ./automated/linux/ota-update
-        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}"
+        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ota-update/verify-reboot.yaml
+++ b/automated/linux/ota-update/verify-reboot.yaml
@@ -22,8 +22,10 @@ params:
         UBOOT_VAR_TOOL: "fw_printenv"
         UBOOT_VAR_SET_TOOL: "fw_setenv"
         TARGET_VERSION: "1"
+        UBOOT_VARIABLE_NAME: "foobar"
+        UBOOT_VARIABLE_VALUE: "baz"
 run:
     steps:
         - cd ./automated/linux/ota-update
-        - ./verify-reboot.sh  -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -v "${TARGET_VERSION}"
+        - ./verify-reboot.sh  -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -v "${TARGET_VERSION}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ota-update/verify-update.sh
+++ b/automated/linux/ota-update/verify-update.sh
@@ -14,10 +14,12 @@ export UBOOT_VAR_TOOL
 UBOOT_VAR_SET_TOOL=fw_setenv
 export UBOOT_VAR_SET_TOOL
 BOOTROM_USE_SECONDARY="true"
+U_BOOT_VARIABLE_NAME="foobar"
+U_BOOT_VARIABLE_VALUE="baz"
 
 usage() {
     echo "\
-    Usage: $0 [-t <kernel|uboot>] [-u <u-boot variable read>] [-s <u-boot variable set>] [-v <expected version>]
+    Usage: $0 [-t <kernel|uboot>] [-u <u-boot variable read>] [-s <u-boot variable set>] [-v <expected version>] [-V <variable name>] [-w <variable value>]
 
     -t <kernel|uboot>
         Defauts to 'kernel'. It either enables or disables
@@ -39,16 +41,23 @@ usage() {
         Defaults to 'true'. When set to 'false' the test
         'fiovb_is_secondary_boot_after_rollback' will use
         0 as a reference value.
+    -V u-boot variable name to be set before the OTA upgrade
+        It is expected that this variable will be preserved through
+        the update process. Default: foobar
+    -w u-boot variable value. This is assigned to the variable set
+        with -v flag. Default: baz
     "
 }
 
-while getopts "t:u:s:v:b:h" opts; do
+while getopts "t:u:s:v:b:V:w:h" opts; do
     case "$opts" in
         t) TYPE="${OPTARG}";;
         u) UBOOT_VAR_TOOL="${OPTARG}";;
         s) UBOOT_VAR_SET_TOOL="${OPTARG}";;
         v) REF_TARGET_VERSION="${OPTARG}";;
         b) BOOTROM_USE_SECONDARY="${OPTARG}";;
+        w) U_BOOT_VARIABLE_VALUE="${OPTARG}";;
+        V) U_BOOT_VARIABLE_NAME="${OPTARG}";;
         h|*) usage ; exit 1 ;;
     esac
 done
@@ -103,6 +112,10 @@ compare_test_value "bootfirmware_version_after_upgrade" "${ref_bootfirmware_vers
 fiovb_is_secondary_boot_after_upgrade=$(uboot_variable_value "${SECONDARY_BOOT_VAR_NAME}")
 compare_test_value "fiovb_is_secondary_boot_after_upgrade" "${ref_fiovb_is_secondary_boot_after_upgrade}" "${fiovb_is_secondary_boot_after_upgrade}"
 
+if [ "${TYPE}" = "uboot" ]; then
+    uboot_variable_after_upgrade=$(uboot_variable_value "${U_BOOT_VARIABLE_NAME}")
+    compare_test_value "${TYPE}_uboot_variable_value_after_upgrade" "${U_BOOT_VARIABLE_VALUE}" "${uboot_variable_after_upgrade}"
+fi
 . /etc/os-release
 # shellcheck disable=SC2154
 compare_test_value "target_version_after_upgrade" "${REF_TARGET_VERSION}" "${IMAGE_VERSION}"

--- a/automated/linux/ota-update/verify-update.yaml
+++ b/automated/linux/ota-update/verify-update.yaml
@@ -23,8 +23,10 @@ params:
         TYPE: "kernel"
         TARGET_VERSION: "1"
         BOOTROM_USE_SECONDARY: "true"
+        UBOOT_VARIABLE_NAME: "foobar"
+        UBOOT_VARIABLE_VALUE: "baz"
 run:
     steps:
         - cd ./automated/linux/ota-update
-        - ./verify-update.sh  -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -v "${TARGET_VERSION}" -b "${BOOTROM_USE_SECONDARY}"
+        - ./verify-update.sh  -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -v "${TARGET_VERSION}" -b "${BOOTROM_USE_SECONDARY}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
This patch adds another check to OTA upgrade test. u-boot of RPMB variable is set before the upgrade. It should not be removed or altered by the upgrade process which is checked after the update.