### PR TITLE
automated: linux: Add debug option to OTA tests

### DIFF
--- a/automated/linux/ota-rollback/download-update.sh
+++ b/automated/linux/ota-rollback/download-update.sh
@@ -14,10 +14,11 @@ UBOOT_VAR_SET_TOOL=fw_setenv
 export UBOOT_VAR_SET_TOOL
 PACMAN_TYPE="ostree+compose_apps"
 UBOOT_IMAGE_NAME="u-boot.itb"
+DEBUG="false"
 
 usage() {
 	echo "\
-	Usage: $0 [-t <kernel|uboot>] [-u <u-boot var read>] [-s <u-boot var set>] [-o <ostree|ostree+compose_apps>]
+	Usage: $0 [-t <kernel|uboot>] [-u <u-boot var read>] [-s <u-boot var set>] [-o <ostree|ostree+compose_apps>] [-d <true|false>]
 
     -t <kernel|uboot|app>
         This determines type of corruption test performed:
@@ -40,16 +41,18 @@ usage() {
         ostree+compose_apps
     -f u-boot image file name to corrupt. On some machines
         u-boot image has different name. Default is u-boot.itb
+    -d <true|false> Enables more debug messages. Default: false
 	"
 }
 
-while getopts "t:u:s:o:f:h" opts; do
+while getopts "t:u:s:o:f:d:h" opts; do
 	case "$opts" in
         t) TYPE="${OPTARG}";;
         u) UBOOT_VAR_TOOL="${OPTARG}";;
         s) UBOOT_VAR_SET_TOOL="${OPTARG}";;
         o) PACMAN_TYPE="${OPTARG}";;
         f) UBOOT_IMAGE_NAME="${OPTARG}";;
+        d) DEBUG="${OPTARG}";;
         h|*) usage ; exit 1 ;;
 	esac
 done
@@ -182,6 +185,10 @@ fi
 UPGRADE_AVAILABLE="${upgrade_available_after_download}"
 if [ "${TYPE}" = "uboot" ]; then
     UPGRADE_AVAILABLE="${bootupgrade_available_after_download}"
+fi
+
+if [ "${DEBUG}" = "true" ]; then
+    journalctl --no-pager -u aktualizr-lite
 fi
 
 if [ "${UPGRADE_AVAILABLE}" -eq 1 ]; then

--- a/automated/linux/ota-rollback/download-update.yaml
+++ b/automated/linux/ota-rollback/download-update.yaml
@@ -23,8 +23,9 @@ params:
         UBOOT_IMAGE_NAME: "u-boot.itb"
         TYPE: "kernel"
         PACMAN_TYPE: "ostree+compose_apps"
+        DEBUG: "false"
 run:
     steps:
         - cd ./automated/linux/ota-rollback
-        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}" -f "${UBOOT_IMAGE_NAME}"
+        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}" -f "${UBOOT_IMAGE_NAME}" -d "${DEBUG}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ota-rollback/verify-reboot.sh
+++ b/automated/linux/ota-rollback/verify-reboot.sh
@@ -12,10 +12,11 @@ UBOOT_VAR_TOOL=fw_printenv
 export UBOOT_VAR_TOOL
 UBOOT_VAR_SET_TOOL=fw_setenv
 export UBOOT_VAR_SET_TOOL
+DEBUG="false"
 
 usage() {
     echo "\
-    Usage: $0 [-type <kernel|uboot>]
+    Usage: $0 [-type <kernel|uboot>] [-u <u-boot var read>] [-s <u-boot var set>] [-d <true|false>]
 
     -t <kernel|uboot>
         This determines type of corruption test
@@ -32,14 +33,16 @@ usage() {
         On the unsecured systems it will usually be
         fw_setenv. On secured systems it might be
         fiovb_setenv
+    -d <true|false> Enables more debug messages. Default: false
     "
 }
 
-while getopts "t:u:s:h" opts; do
+while getopts "t:u:s:d:h" opts; do
     case "$opts" in
         t) TYPE="${OPTARG}";;
         u) UBOOT_VAR_TOOL="${OPTARG}";;
         s) UBOOT_VAR_SET_TOOL="${OPTARG}";;
+        d) DEBUG="${OPTARG}";;
         h|*) usage ; exit 1 ;;
     esac
 done
@@ -90,4 +93,8 @@ else
     report_skip "bootupgrade_available_after_reboot"
     report_skip "bootfirmware_version_after_reboot"
     report_skip "fiovb_is_secondary_boot_after_reboot"
+fi
+
+if [ "${DEBUG}" = "true" ]; then
+    journalctl --no-pager -u aktualizr-lite
 fi

--- a/automated/linux/ota-rollback/verify-reboot.yaml
+++ b/automated/linux/ota-rollback/verify-reboot.yaml
@@ -20,8 +20,9 @@ params:
         UBOOT_VAR_TOOL: "fw_printenv"
         UBOOT_VAR_SET_TOOL: "fw_setenv"
         TYPE: "kernel"
+        DEBUG: "false"
 run:
     steps:
         - cd ./automated/linux/ota-rollback
-        - ./verify-reboot.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}"
+        - ./verify-reboot.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -d "${DEBUG}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ota-rollback/verify-rollback.sh
+++ b/automated/linux/ota-rollback/verify-rollback.sh
@@ -12,10 +12,11 @@ UBOOT_VAR_TOOL=fw_printenv
 export UBOOT_VAR_TOOL
 UBOOT_VAR_SET_TOOL=fw_setenv
 export UBOOT_VAR_SET_TOOL
+DEBUG="false"
 
 usage() {
     echo "\
-    Usage: $0 [-type <kernel|uboot|app>]
+    Usage: $0 [-type <kernel|uboot|app>] [-u <u-boot var read>] [-s <u-boot var set>] [-d <true|false>]
 
     -t <kernel|uboot|app>
         This determines type of corruption test
@@ -33,14 +34,16 @@ usage() {
         On the unsecured systems it will usually be
         fw_setenv. On secured systems it might be
         fiovb_setenv
+    -d <true|false> Enables more debug messages. Default: false
     "
 }
 
-while getopts "t:u:s:h" opts; do
+while getopts "t:u:s:d:h" opts; do
     case "$opts" in
         t) TYPE="${OPTARG}";;
         u) UBOOT_VAR_TOOL="${OPTARG}";;
         s) UBOOT_VAR_SET_TOOL="${OPTARG}";;
+        d) DEBUG="${OPTARG}";;
         h|*) usage ; exit 1 ;;
     esac
 done
@@ -109,3 +112,7 @@ fi
 # for now ignore /etc/os-release
 cat /etc/os-release
 cat /boot/loader/uEnv.txt
+
+if [ "${DEBUG}" = "true" ]; then
+    journalctl --no-pager -u aktualizr-lite
+fi

--- a/automated/linux/ota-rollback/verify-rollback.yaml
+++ b/automated/linux/ota-rollback/verify-rollback.yaml
@@ -20,8 +20,9 @@ params:
         UBOOT_VAR_TOOL: "fw_printenv"
         UBOOT_VAR_SET_TOOL: "fw_setenv"
         TYPE: "kernel"
+        DEBUG: "false"
 run:
     steps:
         - cd ./automated/linux/ota-rollback
-        - ./verify-rollback.sh  -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}"
+        - ./verify-rollback.sh  -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -d "${DEBUG}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ota-update/download-update.sh
+++ b/automated/linux/ota-update/download-update.sh
@@ -15,10 +15,11 @@ export UBOOT_VAR_SET_TOOL
 PACMAN_TYPE="ostree+compose_apps"
 U_BOOT_VARIABLE_NAME="foobar"
 U_BOOT_VARIABLE_VALUE="baz"
+DEBUG="false"
 
 usage() {
 	echo "\
-	Usage: $0 [-t <kernel|uboot>] [-u <u-boot var read>] [-s <u-boot var set>] [-o <ostree|ostree+compose_apps>] [-V <variable name>] [-w <variable value>]
+	Usage: $0 [-t <kernel|uboot>] [-u <u-boot var read>] [-s <u-boot var set>] [-o <ostree|ostree+compose_apps>] [-V <variable name>] [-w <variable value>] [-d <true|false> ]
 
     -t <kernel|uboot>
         This determines type of upgrade test performed:
@@ -43,10 +44,11 @@ usage() {
         the update process. Default: foobar
     -w u-boot variable value. This is assigned to the variable set
         with -v flag. Default: baz
+    -d <true|false> Enables more debug messages. Default: false
 	"
 }
 
-while getopts "t:u:s:o:V:w:h" opts; do
+while getopts "t:u:s:o:V:w:d:h" opts; do
 	case "$opts" in
         t) TYPE="${OPTARG}";;
         u) UBOOT_VAR_TOOL="${OPTARG}";;
@@ -54,6 +56,7 @@ while getopts "t:u:s:o:V:w:h" opts; do
         o) PACMAN_TYPE="${OPTARG}";;
         w) U_BOOT_VARIABLE_VALUE="${OPTARG}";;
         V) U_BOOT_VARIABLE_NAME="${OPTARG}";;
+        d) DEBUG="${OPTARG}";;
         h|*) usage ; exit 1 ;;
 	esac
 done
@@ -202,4 +205,7 @@ fi
 
 if [ "${UPGRADE_AVAILABLE}" -ne 1 ]; then
     lava-test-raise "No-update-available-${TYPE}"
+fi
+if [ "${DEBUG}" = "true" ]; then
+    journalctl --no-pager -u aktualizr-lite
 fi

--- a/automated/linux/ota-update/download-update.yaml
+++ b/automated/linux/ota-update/download-update.yaml
@@ -24,8 +24,9 @@ params:
         PACMAN_TYPE: "ostree+compose_apps"
         UBOOT_VARIABLE_NAME: "foobar"
         UBOOT_VARIABLE_VALUE: "baz"
+        DEBUG: "false"
 run:
     steps:
         - cd ./automated/linux/ota-update
-        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}"
+        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}" -d "${DEBUG}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ota-update/verify-reboot.sh
+++ b/automated/linux/ota-update/verify-reboot.sh
@@ -14,10 +14,11 @@ UBOOT_VAR_SET_TOOL=fw_setenv
 export UBOOT_VAR_SET_TOOL
 U_BOOT_VARIABLE_NAME="foobar"
 U_BOOT_VARIABLE_VALUE="baz"
+DEBUG="false"
 
 usage() {
     echo "\
-    Usage: $0 [-u <u-boot variable read>] [-s <u-boot variable set>] [-v <expected version>] [-V <variable name>] [-w <variable value>]
+    Usage: $0 [-u <u-boot variable read>] [-s <u-boot variable set>] [-v <expected version>] [-V <variable name>] [-w <variable value>] [-d <true|false>]
 
     -v <target version>
         Version of the target expected after reboot.
@@ -37,16 +38,18 @@ usage() {
         the update process. Default: foobar
     -w u-boot variable value. This is assigned to the variable set
         with -v flag. Default: baz
+    -d <true|false> Enables more debug messages. Default: false
     "
 }
 
-while getopts "u:s:v:V:w:h" opts; do
+while getopts "u:s:v:V:w:d:h" opts; do
     case "$opts" in
         u) UBOOT_VAR_TOOL="${OPTARG}";;
         s) UBOOT_VAR_SET_TOOL="${OPTARG}";;
         v) REF_TARGET_VERSION="${OPTARG}";;
         w) U_BOOT_VARIABLE_VALUE="${OPTARG}";;
         V) U_BOOT_VARIABLE_NAME="${OPTARG}";;
+        d) DEBUG="${OPTARG}";;
         h|*) usage ; exit 1 ;;
     esac
 done
@@ -91,3 +94,7 @@ fi
 compare_test_value "target_version_after_upgrade" "${REF_TARGET_VERSION}" "${IMAGE_VERSION}"
 cat /etc/os-release
 cat /boot/loader/uEnv.txt
+
+if [ "${DEBUG}" = "true" ]; then
+    journalctl --no-pager -u aktualizr-lite
+fi

--- a/automated/linux/ota-update/verify-reboot.yaml
+++ b/automated/linux/ota-update/verify-reboot.yaml
@@ -24,8 +24,9 @@ params:
         TARGET_VERSION: "1"
         UBOOT_VARIABLE_NAME: "foobar"
         UBOOT_VARIABLE_VALUE: "baz"
+        DEBUG: "false"
 run:
     steps:
         - cd ./automated/linux/ota-update
-        - ./verify-reboot.sh  -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -v "${TARGET_VERSION}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}"
+        - ./verify-reboot.sh  -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -v "${TARGET_VERSION}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}" -d "${DEBUG}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ota-update/verify-update.sh
+++ b/automated/linux/ota-update/verify-update.sh
@@ -16,10 +16,11 @@ export UBOOT_VAR_SET_TOOL
 BOOTROM_USE_SECONDARY="true"
 U_BOOT_VARIABLE_NAME="foobar"
 U_BOOT_VARIABLE_VALUE="baz"
+DEBUG="false"
 
 usage() {
     echo "\
-    Usage: $0 [-t <kernel|uboot>] [-u <u-boot variable read>] [-s <u-boot variable set>] [-v <expected version>] [-V <variable name>] [-w <variable value>]
+    Usage: $0 [-t <kernel|uboot>] [-u <u-boot variable read>] [-s <u-boot variable set>] [-v <expected version>] [-V <variable name>] [-w <variable value>] [-d <true|false>]
 
     -t <kernel|uboot>
         Defauts to 'kernel'. It either enables or disables
@@ -46,10 +47,11 @@ usage() {
         the update process. Default: foobar
     -w u-boot variable value. This is assigned to the variable set
         with -v flag. Default: baz
+    -d <true|false> Enables more debug messages. Default: false
     "
 }
 
-while getopts "t:u:s:v:b:V:w:h" opts; do
+while getopts "t:u:s:v:b:V:w:d:h" opts; do
     case "$opts" in
         t) TYPE="${OPTARG}";;
         u) UBOOT_VAR_TOOL="${OPTARG}";;
@@ -58,6 +60,7 @@ while getopts "t:u:s:v:b:V:w:h" opts; do
         b) BOOTROM_USE_SECONDARY="${OPTARG}";;
         w) U_BOOT_VARIABLE_VALUE="${OPTARG}";;
         V) U_BOOT_VARIABLE_NAME="${OPTARG}";;
+        d) DEBUG="${OPTARG}";;
         h|*) usage ; exit 1 ;;
     esac
 done
@@ -121,3 +124,7 @@ fi
 compare_test_value "target_version_after_upgrade" "${REF_TARGET_VERSION}" "${IMAGE_VERSION}"
 cat /etc/os-release
 cat /boot/loader/uEnv.txt
+
+if [ "${DEBUG}" = "true" ]; then
+    journalctl --no-pager -u aktualizr-lite
+fi

--- a/automated/linux/ota-update/verify-update.yaml
+++ b/automated/linux/ota-update/verify-update.yaml
@@ -25,8 +25,9 @@ params:
         BOOTROM_USE_SECONDARY: "true"
         UBOOT_VARIABLE_NAME: "foobar"
         UBOOT_VARIABLE_VALUE: "baz"
+        DEBUG: "false"
 run:
     steps:
         - cd ./automated/linux/ota-update
-        - ./verify-update.sh  -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -v "${TARGET_VERSION}" -b "${BOOTROM_USE_SECONDARY}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}"
+        - ./verify-update.sh  -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -v "${TARGET_VERSION}" -b "${BOOTROM_USE_SECONDARY}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}" -d "${DEBUG}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
This commit allows to print aktualizr-lite logs at the end of the test. DEBUG flag is turned off by default.