### PR TITLE
automated: linux: device registration with HSM module

### DIFF
--- a/automated/linux/factory-reset/prepare-reset.yaml
+++ b/automated/linux/factory-reset/prepare-reset.yaml
@@ -15,6 +15,9 @@ metadata:
 
       If higher priority type is present, lower priority
       type is ignored.
+
+      Device can be registered with specifig tag using LABEL variable.
+      Device can be registered with HSM using HSM_MODULE variable.
       "
 
     maintainer:
@@ -35,8 +38,9 @@ params:
         # TYPE and ADDITIONAL_TYPE
         ADDITIONAL_TYPE: ""
         LABEL: ""
+        HSM_MODULE: ""
 run:
     steps:
         - cd ./automated/linux/factory-reset
-        - ./prepare-reset.sh -t "${TYPE}" -a "${ADDITIONAL_TYPE}" -l "${LABEL}"
+        - ./prepare-reset.sh -t "${TYPE}" -a "${ADDITIONAL_TYPE}" -l "${LABEL}" -S "${HSM_MODULE}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/ota-update/download-update.yaml
+++ b/automated/linux/ota-update/download-update.yaml
@@ -25,8 +25,9 @@ params:
         UBOOT_VARIABLE_NAME: "foobar"
         UBOOT_VARIABLE_VALUE: "baz"
         DEBUG: "false"
+        HSM_MODULE: ""
 run:
     steps:
         - cd ./automated/linux/ota-update
-        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}" -d "${DEBUG}"
+        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}" -V "${UBOOT_VARIABLE_NAME}" -w "${UBOOT_VARIABLE_VALUE}" -d "${DEBUG}" -S "${HSM_MODULE}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
This patch allows to register device to FoundriesFactory using HSM. It's enabled in ota-update and factory-reset tests. Main use case is to test registration with SE050 devices from NXP.