### PR TITLE
Fix .readthedocs.yml file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,11 @@
 version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
 mkdocs:
   configuration: mkdocs.yml
 formats: all
 python:
-  version: 3.7
   install:
     - requirements: mkdocs_plugin/requirements.txt


### PR DESCRIPTION
Readthedocs build automation has a new format. This patch fixes build errors for https://test-definitions.readthedocs.io/