### PR TITLE
docs: fix automated docs generation

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,3 @@
+# Tags
+
+<!-- material/tags -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,8 @@ plugins:
             - 'automated/linux'
             - 'automated/android'
             - 'manual'
-    - tags
+    - tags:
+        tags_file: tags.md
     - exclude:
         glob:
           - plans/*

--- a/mkdocs_plugin/testdefinitionsmkdocs/__init__.py
+++ b/mkdocs_plugin/testdefinitionsmkdocs/__init__.py
@@ -51,11 +51,11 @@ class LinaroTestDefinitionsMkDocsPlugin(BasePlugin):
                 mdFile = mdutils.MdUtils(file_name=tmp_filename)
                 tags_section = "---\n"
                 tags_section += "title: %s\n" % metadata["name"]
-                tags_section += "tags:\n"
                 scope_list = metadata.get("scope", [])
                 os_list = metadata.get("os", [])
                 device_list = metadata.get("devices", [])
-                if scope_list is not None:
+                if scope_list:
+                    tags_section += "tags:\n"
                     for item in scope_list:
                         tags_section += " - %s\n" % item
                 tags_section += "---\n"


### PR DESCRIPTION
New version of material theme and plugins breaks when there is empty "tags" stanza in the metadata section of the markdown. This patch only adds "tags" if there are any to add.

Second issue fixed is adding an empty tags.md file which is now required to present collected tags in the generated docs.