### PR TITLE
Actions: Remove python-dep

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,9 +5,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-plans-pipeline.yml
+++ b/.github/workflows/test-plans-pipeline.yml
@@ -5,9 +5,6 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.6]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We shouldn't lock down to old python version.