### PR TITLE
noninteractive-tradefed: stop using the latest adb

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -22,7 +22,6 @@ case "${dist}" in
         ;;
 esac
 
-install_latest_adb
 initialize_adb
 adb_root
 


### PR DESCRIPTION
instead using the default version in the system,
either installed by the user manually or installed
inside some docker image, to avoid confusions caused by
unmanaged adb versions, like the "ADB server didn't ACK"
issue with the current latest adb version(platform-tools r35)
reported here:
https://lkft.validation.linaro.org/scheduler/job/7266683#L15671
