### PR TITLE
Add support to upload artifacts to SQUAD server

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -25,6 +25,11 @@ params:
     TEST_PATH: "android-cts"
     # Specify result format: aggregated or atomic
     RESULTS_FORMAT: "aggregated"
+    # The SQUAD url to be used to upload the result and log files.
+    # see https://squad.readthedocs.io/en/latest/intro.html#submitting-results.
+    # SQUAD_ARCHIVE_SUBMIT_TOKEN is used for uploading authentication,
+    # and must be defined by the submitter as one profile managed token
+    SQUAD_UPLOAD_URL: ""
     # Specify url and token for file uploading.
     URL: "https://archive.validation.linaro.org/artifacts/team/qa/"
     TOKEN: ""
@@ -65,7 +70,8 @@ run:
         - sudo dmesg > ./output/dmesg-host.txt || true
         - if ! tar caf tradefed-output-$(date +%Y%m%d%H%M%S).tar.xz ./output; then error_fatal "tradefed - failed to collect results and log files [$ANDROID_SERIAL]"; fi
         - ATTACHMENT=$(ls tradefed-output-*.tar.xz)
-        - ../../utils/upload-to-artifactorial.sh -a "${ATTACHMENT}" -u "${URL}" -t "${TOKEN}"
+        - if [ -n "${SQUAD_UPLOAD_URL}" ]; then ../../utils/upload-to-squad.sh -a "${ATTACHMENT}" -u "${SQUAD_UPLOAD_URL}"; fi
+        - if [ -z "${SQUAD_UPLOAD_URL}" ]; then ../../utils/upload-to-artifactorial.sh -a "${ATTACHMENT}" -u "${URL}" -t "${TOKEN}"; fi
         # Send test result to LAVA.
         - ../../utils/send-to-lava.sh ./output/result.txt
         - userdel testuser -f -r || true

--- a/automated/utils/upload-to-squad.sh
+++ b/automated/utils/upload-to-squad.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+ATTACHMENT=""
+ARTIFACTORIAL_URL=""
+CURL_VERBOSE_FLAG=""
+FAILURE_RETURN_VALUE=0
+
+usage() {
+    echo "Usage: $0 [-a <attachment>] [-u <artifactorial_url>] [-v] [-r]" 1>&2
+    echo "  -a attachment           Path to the file to upload" 1>&2
+    echo "  -u squad_url            SQUAD_URL where the attachment will be uploaded to" 1>&2
+    echo "                          This script will try to fetch the SQUAD_ARCHIVE_SUBMIT_TOKEN" 1>&2
+    echo "                          token from (lava_test_dir)/secrets or environments for the upload." 1>&2
+    echo "  -v      Pass -v (verbose) flag to curl for debugging." 1>&2
+    echo "  -r      Report failure. If the upload fails and this flag is set, the script will exit" 1>&2
+    echo "          with return value 1. If the upload is skipped (no URL or no token found)," 1>&2
+    echo "          this script will still return 0." 1>&2
+    exit 1
+}
+
+while getopts ":a:u:vr" opt; do
+    case "${opt}" in
+        a) ATTACHMENT="${OPTARG}" ;;
+        u) ARTIFACTORIAL_URL="${OPTARG}" ;;
+        v) CURL_VERBOSE_FLAG="-v" ;;
+        r) FAILURE_RETURN_VALUE=1 ;;
+        *) usage ;;
+    esac
+done
+
+if [ -z "${ARTIFACTORIAL_URL}" ]; then
+    echo "test-attachment skip"
+    command -v lava-test-case > /dev/null 2>&1 && lava-test-case "test-attachment" --result "skip"
+    exit 0
+fi
+
+if command -v lava-test-reference > /dev/null 2>&1; then
+    # The 'SQUAD_ARCHIVE_SUBMIT_TOKEN' needs to be defined in 'secrects' dictionary in job
+    # definition file, or defined in the environment, it will be used.
+    # One issue here Milosz pointed out:
+    #    If there is lava_test_results_dir set in the job context, "/lava-*" might not be correct.
+    lava_test_dir="$(find /lava-* -maxdepth 0 -type d | grep -E '^/lava-[0-9]+' 2>/dev/null | sort | tail -1)"
+    if test -f "${lava_test_dir}/secrets"; then
+        # shellcheck disable=SC1090
+        . "${lava_test_dir}/secrets"
+    fi
+
+    if [ -z "${SQUAD_ARCHIVE_SUBMIT_TOKEN}" ]; then
+        echo "WARNING: SQUAD_ARCHIVE_SUBMIT_TOKEN is empty! File uploading skipped."
+        echo "test-attachment skip"
+        command -v lava-test-case > /dev/null 2>&1 && lava-test-case "test-attachment" --result "skip"
+        exit 0
+    else
+        # return is the squad testrun id
+        return=$(curl ${CURL_VERBOSE_FLAG} --header "Auth-Token: ${SQUAD_ARCHIVE_SUBMIT_TOKEN}" --form "attachment=@${ATTACHMENT}" "${ARTIFACTORIAL_URL}")
+    fi
+
+    attachmentBasename="$(basename "${ATTACHMENT}")"
+    if echo "${return}" | grep -E "^[0-9]+$"; then
+        # ARTIFACTORIAL_URL will be in the format like this:
+        #    https://qa-reports.linaro.org/api/submit/squad_group/squad_project/squad_build/environment
+        url_squad=$(echo "${ARTIFACTORIAL_URL}"|sed 's|/api/submit/.*||')
+        url_uploaded="${url_squad}/api/testruns/${return}/attachments/?filename=${attachmentBasename}"
+        lava-test-reference "test-attachment" --result "pass" --reference "${url_uploaded}"
+    else
+        echo "test-attachment fail"
+        echo "Expected one SQUAD testrun id returend, but curl returned \"${return}\"."
+        command -v lava-test-case > /dev/null 2>&1 && lava-test-case "test-attachment" --result "fail"
+        exit "${FAILURE_RETURN_VALUE}"
+    fi
+else
+    echo "test-attachment skip"
+    command -v lava-test-case > /dev/null 2>&1 && lava-test-case "test-attachment" --result "skip"
+fi


### PR DESCRIPTION
With the automated/utils/upload-to-squad.sh added and the change on the noninteractive-tradefe test as an example in this pull request. there are other tests need to be update as well after pull request.

The SQUAD url should be defined in the format like described here:
https://squad.readthedocs.io/en/latest/intro.html#submitting-results

And the job definition, SQUAD_ARCHIVE_SUBMIT_TOKEN should be defined under the secrets section.
```yaml
secrets:
  SQUAD_ARCHIVE_SUBMIT_TOKEN: SQUAD_ARCHIVE_SUBMIT_TOKEN 
```
And SQUAD_UPLOAD_URL should be defined as one parameter like:
```yaml
- test:
    ...
    definitions:
    - repository: https://github.com/Linaro/test-definitions.git
      from: git
      path: automated/android/noninteractive-tradefed/tradefed.yaml
      params:
        ...
        SQUAD_UPLOAD_URL: https://qa-reports.linaro.org/api/submit/squad_group/squad_project/squad_build/environment 
      name: cts-lkft
```
