### PR TITLE
automated: linux: fix registration in aklite interrupt

### DIFF
--- a/automated/linux/aklite-download-interrupt/aklite-download-interrupt.sh
+++ b/automated/linux/aklite-download-interrupt/aklite-download-interrupt.sh
@@ -66,8 +66,7 @@ find /sysroot/ostree/repo/ -samefile $(find /usr/ -name "*vmlinuz*") -delete
 set +x
 
 # run autoregistration script
-lmp-device-auto-register
-check_return "lmp-device-auto-register" || error_fatal "Unable to register device"
+systemctl enable --now lmp-device-auto-register || error_fatal "Unable to register device"
 
 # wait for 'download-pre' signal
 SIGNAL=$(</var/sota/ota.signal)


### PR DESCRIPTION
This patch fixes call to lmp-device-auto-register in aklite-download-interupt tests. The script has to be called from systemd service which sets up proper variables.