### PR TITLE
automated: linux: fix toml parsing in lmp-device-register

### DIFF
--- a/automated/linux/lmp-device-register/check_toml.py
+++ b/automated/linux/lmp-device-register/check_toml.py
@@ -12,7 +12,7 @@ def main(toml_file):
         import toml as tlib
 
     with open(toml_file, "rb") as f:
-        tlib.load(f)
+        tlib.loads(f.read().decode())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Python libraries toml and tomllib are not API compatible. This patch switches the code to use a part of API that is the same in both libraries.