### PR TITLE
spectre-meltdown-checker: Update to v0.46

### DIFF
--- a/automated/linux/spectre-meltdown-checker-test/spectre-meltdown-checker-test.sh
+++ b/automated/linux/spectre-meltdown-checker-test/spectre-meltdown-checker-test.sh
@@ -6,7 +6,7 @@ OUTPUT="$(pwd)/output"
 RESULT_FILE="${OUTPUT}/result.txt"
 LOG_FILE="smc_logfile"
 export RESULT_FILE
-SMC_VERSION=v0.45
+SMC_VERSION=v0.46
 SKIP_INSTALL="False"
 WGET_UPSTREAM="False"
 SMC_PATH=/opt/spectre-meltdown-checker

--- a/automated/linux/spectre-meltdown-checker-test/spectre-meltdown-checker-test.yaml
+++ b/automated/linux/spectre-meltdown-checker-test/spectre-meltdown-checker-test.yaml
@@ -21,7 +21,7 @@ metadata:
         - lava-test-shell
 params:
     # Spectre meltdown checker version
-    SMC_VERSION: v0.45
+    SMC_VERSION: v0.46
     SKIP_INSTALL: "False"
     WGET_UPSTREAM: "False"
 


### PR DESCRIPTION
Release notes for v0.46:
https://github.com/speed47/spectre-meltdown-checker/releases/tag/v0.46