### PR TITLE
kselftest: Add new option -E for specifying environment variables

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -44,11 +44,12 @@ usage() {
                     [-S kselftest-skipfile]
                     [-b board]
                     [-g branch]
-                    [-e environment]" 1>&2
+                    [-e environment]
+                    [-E ENV_NAME=ENV_VAL]" 1>&2
     exit 1
 }
 
-while getopts "i:n:c:T:t:s:u:p:L:S:b:g:e:h" opt; do
+while getopts "i:n:c:T:t:s:u:p:L:S:b:g:e:E:h" opt; do
     case "${opt}" in
         i) SHARD_INDEX="${OPTARG}" ;;
         n) SHARD_NUMBER="${OPTARG}" ;;
@@ -106,6 +107,13 @@ while getopts "i:n:c:T:t:s:u:p:L:S:b:g:e:h" opt; do
             ;;
         e)
             export ENVIRONMENT="${OPTARG}"
+            ;;
+        E)
+            if [ -n "${OPTARG}" ]; then
+                set -x
+                eval "export ${OPTARG}"
+                set +x
+            fi
             ;;
         h|*) usage ;;
     esac

--- a/automated/linux/kselftest/kselftest.yaml
+++ b/automated/linux/kselftest/kselftest.yaml
@@ -50,6 +50,9 @@ params:
     BOARD: ""
     BRANCH: ""
     ENVIRONMENT: ""
+    # Set arbitrary environment variables. The value set here is directly evaluated
+    # as `eval "export ${ENV}"`.
+    ENV: ""
 
     # Number of shards that will be done, default 1 which is the same as no sharding.
     SHARD_NUMBER: 1
@@ -60,5 +63,5 @@ params:
 run:
     steps:
         - cd ./automated/linux/kselftest/
-        - ./kselftest.sh -c "${TST_CMDFILES}" -T "${TST_CASENAME}" -t "${TESTPROG}" -s "${SKIP_INSTALL}" -u "${TESTPROG_URL}" -L "${SKIPLIST}" -S "${SKIPFILE}" -b "${BOARD}" -g "${BRANCH}" -e "${ENVIRONMENT}" -p "${KSELFTEST_PATH}" -n "${SHARD_NUMBER}" -i "${SHARD_INDEX}"
+        - ./kselftest.sh -c "${TST_CMDFILES}" -T "${TST_CASENAME}" -t "${TESTPROG}" -s "${SKIP_INSTALL}" -u "${TESTPROG_URL}" -L "${SKIPLIST}" -S "${SKIPFILE}" -b "${BOARD}" -g "${BRANCH}" -e "${ENVIRONMENT}" -p "${KSELFTEST_PATH}" -n "${SHARD_NUMBER}" -i "${SHARD_INDEX}" -E "${ENV}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Currently we are not able to run the subtests of a kselftest due to lack of support for passing the parameters to the test case. Hence, solve this problem by adding support for passing environment variables in KernelCI kselftest.