### PR TITLE
automated: linux: enable custom path for OTA rollback u-boot

### DIFF
--- a/automated/linux/ota-rollback/download-update.sh
+++ b/automated/linux/ota-rollback/download-update.sh
@@ -18,8 +18,8 @@ DEBUG="false"
 SOTA_CONFDIR="/etc/sota/conf.d"
 
 usage() {
-	echo "\
-	Usage: $0 [-t <kernel|uboot>] [-u <u-boot var read>] [-s <u-boot var set>] [-o <ostree|ostree+compose_apps>] [-d <true|false>]
+    echo "\
+    Usage: $0 [-t <kernel|uboot>] [-u <u-boot var read>] [-s <u-boot var set>] [-o <ostree|ostree+compose_apps>] [-d <true|false>]
 
     -t <kernel|uboot|app>
         This determines type of corruption test performed:
@@ -50,11 +50,11 @@ usage() {
         DEPLOYMENT_HASH ostree commit ID and is used in the
         filesystem paths.
     -d <true|false> Enables more debug messages. Default: false
-	"
+    "
 }
 
 while getopts "t:u:s:o:f:d:h" opts; do
-	case "$opts" in
+    case "$opts" in
         t) TYPE="${OPTARG}";;
         u) UBOOT_VAR_TOOL="${OPTARG}";;
         s) UBOOT_VAR_SET_TOOL="${OPTARG}";;
@@ -64,7 +64,7 @@ while getopts "t:u:s:o:f:d:h" opts; do
             ;;
         d) DEBUG="${OPTARG}";;
         h|*) usage ; exit 1 ;;
-	esac
+    esac
 done
 
 # the script works only on builds with aktualizr-lite
@@ -156,9 +156,9 @@ fi
 # wait for 'install-post' signal
 while ! grep "install-post" /var/sota/ota.signal
 do
-	echo "Sleeping 1s"
-	sleep 1
-	cat /var/sota/ota.signal
+    echo "Sleeping 1s"
+    sleep 1
+    cat /var/sota/ota.signal
 done
 report_pass "${TYPE}-install-post-received"
 

--- a/automated/linux/ota-rollback/download-update.yaml
+++ b/automated/linux/ota-rollback/download-update.yaml
@@ -20,12 +20,13 @@ metadata:
 params:
         UBOOT_VAR_TOOL: "fw_printenv"
         UBOOT_VAR_SET_TOOL: "fw_setenv"
-        UBOOT_IMAGE_NAME: "u-boot.itb"
+        # use double escape before $
+        UBOOT_IMAGE_PATH: "/sysroot/ostree/deploy/lmp/deploy/\\${DEPLOYMENT_HASH}/usr/lib/firmware/u-boot.itb"
         TYPE: "kernel"
         PACMAN_TYPE: "ostree+compose_apps"
         DEBUG: "false"
 run:
     steps:
         - cd ./automated/linux/ota-rollback
-        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}" -f "${UBOOT_IMAGE_NAME}" -d "${DEBUG}"
+        - ./download-update.sh -t "${TYPE}" -u "${UBOOT_VAR_TOOL}" -s "${UBOOT_VAR_SET_TOOL}" -o "${PACMAN_TYPE}" -f "${UBOOT_IMAGE_PATH}" -d "${DEBUG}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
This patch allows to corrupt u-boot image in arbitrary path. It's required for systems that use LUKS encryption. When LUKS is used, after downloading an update, bootloader files are copied to unencrypted partition, from where they can be read by u-boot runtime.