### PR TITLE
automated: linux: ltp: add support for the new kirk runner

### DIFF
--- a/automated/linux/ltp/ltp.yaml
+++ b/automated/linux/ltp/ltp.yaml
@@ -39,6 +39,11 @@ params:
     # root's password. Needed by ltp/su01.
     ROOT_PASSWD: root
 
+    # New kirk runner (https://github.com/linux-test-project/kirk.git)
+    # Needs to be installed onto the rootfs.
+    # Set RUNNER to full path to kik or to kirk if its in the PATH.
+    RUNNER: ""
+
     # If the following parameter is set, then the LTP suite is
     # cloned and used unconditionally. In particular, the version
     # of the suite is set to the commit pointed to by the
@@ -71,5 +76,5 @@ params:
 run:
     steps:
         - cd ./automated/linux/ltp/
-        - ./ltp.sh -T "${TST_CMDFILES}" -s "${SKIP_INSTALL}" -v "${LTP_VERSION}" -M "${TIMEOUT_MULTIPLIER}" -R "${ROOT_PASSWD}" -b "${BOARD}" -d "${LTP_TMPDIR}" -g "${BRANCH}" -e "${ENVIRONMENT}" -i "${LTP_INSTALL_PATH}" -S "${SKIPFILE}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}" -t "${BUILD_FROM_TAR}" -n "${SHARD_NUMBER}" -c "${SHARD_INDEX}"
+        - ./ltp.sh -T "${TST_CMDFILES}" -s "${SKIP_INSTALL}" -v "${LTP_VERSION}" -M "${TIMEOUT_MULTIPLIER}" -R "${ROOT_PASSWD}" -r "${RUNNER}" -b "${BOARD}" -d "${LTP_TMPDIR}" -g "${BRANCH}" -e "${ENVIRONMENT}" -i "${LTP_INSTALL_PATH}" -S "${SKIPFILE}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}" -t "${BUILD_FROM_TAR}" -n "${SHARD_NUMBER}" -c "${SHARD_INDEX}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
LTP has depricated their runltp runner to run tests. The new one is called kirk
(https://github.com/linux-test-project/kirk.git) which replaces runltp. For now runltp will be the default runner. If someone wants to use kirk, it has to be pre-installed into the rootfs, and the yaml varialbe RUNNER has to be set to 'kirk' or '/usr/local/bin/kirk'.