### PR TITLE
automated: linux: support hello-world docker image from mirrors

### DIFF
--- a/automated/linux/docker/docker.sh
+++ b/automated/linux/docker/docker.sh
@@ -50,7 +50,7 @@ systemctl start docker
 exit_on_fail "start-docker-service" "${skip_list}"
 
 case "${IMAGE}" in
-    hello-world)
+    *hello-world)
         docker run --rm "${IMAGE}"
         ;;
     *)


### PR DESCRIPTION
This patch enables "hello-world" image testing from Amazon mirror. It's required for cases where hub.docker.com is not available.