### PR TITLE
automated: linux: modules: add SKIPLIST

### DIFF
--- a/automated/linux/modules/modules.yaml
+++ b/automated/linux/modules/modules.yaml
@@ -16,6 +16,10 @@ metadata:
         - x86
 
 params:
+    # If SKIPLIST is specified with a list of space separated modules then
+    # they will be filtered out and not loaded.
+    SKIPLIST: ""
+
     # If MODULES_LIST is specified with a list of space separated modules then
     # MOUDLES_SUBDIRS wont have any affect.
     MODULES_LIST: ""
@@ -36,5 +40,5 @@ params:
 run:
     steps:
         - cd ./automated/linux/modules/
-        - ./modules.sh -d "${MODULES_SUBDIRS}" -l "${MODULES_LIST}" -c "${MODULE_MODPROBE_NUMBER}" -n "${SHARD_NUMBER}" -i "${SHARD_INDEX}"
+        - ./modules.sh -d "${MODULES_SUBDIRS}" -l "${MODULES_LIST}" -c "${MODULE_MODPROBE_NUMBER}" -n "${SHARD_NUMBER}" -i "${SHARD_INDEX}" -s "${SKIPLIST}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Make it possible to skip problematic modules that is known to fail.