### PR TITLE
rt-tests: allow to run threads on all cores

### DIFF
--- a/automated/linux/cyclicdeadline/cyclicdeadline.sh
+++ b/automated/linux/cyclicdeadline/cyclicdeadline.sh
@@ -35,6 +35,10 @@ done
 ! check_root && error_msg "Please run this script as root."
 create_out_dir "${OUTPUT}"
 
+if [ "${THREADS}" -eq "0" ]; then
+    THREADS=$(nproc)
+fi
+
 # Run cyclicdeadline.
 if ! binary=$(command -v cyclicdeadline); then
     detect_abi

--- a/automated/linux/cyclicdeadline/cyclicdeadline.yaml
+++ b/automated/linux/cyclicdeadline/cyclicdeadline.yaml
@@ -33,6 +33,7 @@ params:
     # Step size in us.
     STEP: "500"
     # Number of threads to test
+    # A value of "0" will run a thread per available CPU.
     THREADS: "1"
     # Execute cyclicdeadline for given time
     DURATION: "5m"

--- a/automated/linux/cyclictest/cyclictest.sh
+++ b/automated/linux/cyclictest/cyclictest.sh
@@ -39,6 +39,11 @@ done
 ! check_root && error_msg "Please run this script as root."
 create_out_dir "${OUTPUT}"
 
+if [ "${THREADS}" -eq "0" ]; then
+    THREADS=$(nproc)
+    AFFINITY="all"
+fi
+
 if [ -n "${HISTOGRAM}" ]; then
     HISTOGRAM="-h ${HISTOGRAM}"
 else

--- a/automated/linux/cyclictest/cyclictest.yaml
+++ b/automated/linux/cyclictest/cyclictest.yaml
@@ -33,6 +33,8 @@ params:
     # Base interval of thread in us.
     INTERVAL: "1000"
     # Number of threads.
+    # A value of "0" will run a thread per available CPU and overwrite the
+    # AFFINITY mask to "all"
     THREADS: "1"
     # Set the affinity
     AFFINITY: "0"

--- a/automated/linux/signaltest/signaltest.sh
+++ b/automated/linux/signaltest/signaltest.sh
@@ -31,6 +31,10 @@ done
 ! check_root && error_msg "Please run this script as root."
 create_out_dir "${OUTPUT}"
 
+if [ "${THREADS}" -eq "0" ]; then
+    THREADS=$(nproc)
+fi
+
 # Run signaltest.
 if ! binary=$(command -v signaltest); then
     detect_abi

--- a/automated/linux/signaltest/signaltest.yaml
+++ b/automated/linux/signaltest/signaltest.yaml
@@ -29,7 +29,9 @@ params:
     # Priority of highest prio thread.
     PRIORITY: "98"
     # Number of threads.
+    # A value of "0" will run a thread per available CPU.
     THREADS: "2"
+    # Execute cyclictest for given time
     DURATION: "1m"
     # Background workload to be run during the meassurement
     BACKGROUND_CMD: ""


### PR DESCRIPTION
`cyclideadline`, `cyclictest` and `signaltest` are able to run a test thread per core. Extend the wrapper script so that it's possible to run a thread an all available cores as second default option. Any other setting e.g. run 2 threads on the last two CPUs is hardware/test setup dependent.

One other maybe sane default would be to run threads an all but the first CPU which acts as a housekeeping CPU. But let's keep it simple and see if this is actually a real use case.
