### PR TITLE
linux: ethernet: Fix grep parameter case for busybox

### DIFF
--- a/automated/linux/ethernet/ethernet.sh
+++ b/automated/linux/ethernet/ethernet.sh
@@ -37,7 +37,7 @@ ip addr
 ip addr show "${INTERFACE}"
 
 # Get IP address of a given interface
-IP_ADDR=$(ip addr show "${INTERFACE}" | grep -a2 "state UP" | tail -1 | awk '{print $2}' | cut -f1 -d'/')
+IP_ADDR=$(ip addr show "${INTERFACE}" | grep -A2 "state UP" | tail -1 | awk '{print $2}' | cut -f1 -d'/')
 
 [ -n "${IP_ADDR}" ]
 exit_on_fail "ethernet-ping-state-UP" "ethernet-ping-route"


### PR DESCRIPTION
The -A parameter has to be uppercase to work with busybox. As far as I can see it is uppercase in the help of different Linux, but seems to work in lowercase too - but not in busybox.