### PR TITLE
automated: linux: rtla: ignore summary info

### DIFF
--- a/automated/linux/rtla/parse_rtla.py
+++ b/automated/linux/rtla/parse_rtla.py
@@ -55,13 +55,19 @@ def get_sysinfo():
     return sysinfo
 
 
+def get_field_name(col):
+    if col[0].endswith(":"):
+        return col[0][:-1]
+    return None
+
+
 def parse_histogram(col, sel, i, hist):
     if i not in hist:
         hist[i] = {}
         hist[i]["histogram"] = {}
 
-    if col[0].endswith(":"):
-        name = col[0][:-1]
+    name = get_field_name(col)
+    if name:
         hist[i][name] = int(col[sel])
     else:
         hist[i]["histogram"][col[0]] = int(col[sel])
@@ -70,11 +76,16 @@ def parse_histogram(col, sel, i, hist):
 def parse_osnoise(result_file):
     data = {}
     threads = {}
+    num_cols = 0
+
     for line in result_file.readlines():
         if line.startswith(" "):
             continue
 
         col = line.split()
+        name = get_field_name(col)
+        if name == "ALL":
+            break
 
         num_cols = len(col) - 1
 
@@ -96,11 +107,15 @@ def parse_timerlat(result_file):
     threads = {}
     irqs = {}
     num_cols = 0
+
     for line in result_file.readlines():
         if line.startswith(" "):
             continue
 
         col = line.split()
+        name = get_field_name(col)
+        if name == "ALL":
+            break
 
         num_cols = len(col) - 1
 

--- a/automated/linux/rtla/rtla-osnoise.sh
+++ b/automated/linux/rtla/rtla-osnoise.sh
@@ -33,11 +33,11 @@ background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 
 # real-time priority FIFO:1, on all CPUs, for 900ms at each period (1s by default)
 rtla osnoise hist -P F:1 -r 900000 -d "${DURATION}" --no-header --trace \
-     -e osnoise:irq_noise \
+     --event osnoise:irq_noise \
      --trigger hist:key=cpu,desc,duration.buckets=1000:sort=duration \
-     -e osnoise:thread_noise \
+     --event osnoise:thread_noise \
      --trigger hist:key=cpu,comm,duration.buckets=1000:sort=duration \
-     -e osnoise:sample_threshold \
+     --event osnoise:sample_threshold \
      --trigger 'hist:key=cpu,duration.buckets=1000:sort=duration if interference == 0' \
     | tee -a "${TMPFILE}"
 

--- a/automated/linux/rtla/rtla-timerlat.sh
+++ b/automated/linux/rtla/rtla-timerlat.sh
@@ -32,9 +32,9 @@ create_out_dir "${OUTPUT}"
 background_process_start bgcmd --cmd "${BACKGROUND_CMD}"
 
 rtla timerlat hist --dma-latency=0 -d "${DURATION}" --no-header --trace \
-     -e osnoise:irq_noise \
+     --event osnoise:irq_noise \
      --trigger hist:key=cpu,desc,duration.buckets=1000:sort=duration \
-     -e osnoise:thread_noise \
+     --event osnoise:thread_noise \
      --trigger hist:key=cpu,comm,duration.buckets=1000:sort=duration \
     | tee -a "${TMPFILE}"
 


### PR DESCRIPTION
The rtla tool puts out starting with the "ALL:" line a summary. This
confused the parser and we only report per thread/cpu anyway. So just
ignore it.

Signed-off-by: Daniel Wagner <wagi@monom.org>

Fixes: https://github.com/Linaro/test-definitions/issues/530