### PR TITLE
noninteractive-tradefed: enable skipping of internet access check

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -23,6 +23,9 @@ FAILURES_PRINTED="0"
 AP_SSID=""
 # WIFI AP KEY
 AP_KEY=""
+# default to set the wifi(when required) and check the internet when not specified or set to true
+# which means it needs to specify explicitly to false to not check the internet access
+INTERNET_ACCESS="true"
 
 check_internet_access() {
     if [ -n "${AP_SSID}" ] && [ -n "${AP_KEY}" ]; then
@@ -75,11 +78,11 @@ check_internet_access() {
 }
 
 usage() {
-    echo "Usage: $0 [-o timeout] [-n serialno] [-c cts_url] [-t test_params] [-p test_path] [-r <aggregated|atomic>] [-f failures_printed] [-a <ap_ssid>] [-k <ap_key>]" 1>&2
+    echo "Usage: $0 [-o timeout] [-n serialno] [-c cts_url] [-t test_params] [-p test_path] [-r <aggregated|atomic>] [-f failures_printed] [-a <ap_ssid>] [-k <ap_key>] [ -i [true|false]]" 1>&2
     exit 1
 }
 
-while getopts ':o:n:c:t:p:r:f:a:k:' opt; do
+while getopts ':o:n:c:t:p:r:f:a:k:i:' opt; do
     case "${opt}" in
         o) TIMEOUT="${OPTARG}" ;;
         n) export ANDROID_SERIAL="${OPTARG}" ;;
@@ -90,6 +93,7 @@ while getopts ':o:n:c:t:p:r:f:a:k:' opt; do
         f) FAILURES_PRINTED="${OPTARG}" ;;
         a) AP_SSID="${OPTARG}" ;;
         k) AP_KEY="${OPTARG}" ;;
+        i) INTERNET_ACCESS="${OPTARG}" ;; # if check the internet access
         *) usage ;;
     esac
 done
@@ -132,7 +136,9 @@ if [ -e "${TEST_PATH}/testcases/vts/testcases/kernel/linux_kselftest/kselftest_c
     sed -i "/suspend/d" "${TEST_PATH}"/testcases/vts/testcases/kernel/linux_kselftest/kselftest_config.py
 fi
 
-check_internet_access
+if [ "X${INTERNET_ACCESS}" = "Xtrue" ] && [ "X${INTERNET_ACCESS}" = "XTrue" ]; then
+    check_internet_access
+fi
 
 # Run tradefed test.
 info_msg "About to run tradefed shell on device ${ANDROID_SERIAL}"

--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -46,6 +46,9 @@ params:
     # when we need to set the DUT to be run in the powersave governor policy
     # to avoid shutting down by high temperature when run the cts vts test
     SET_GOVERNOR_POWERSAVE: "false"
+    # By default, WiFi setup and internet access checks are enabled (INTERNET_ACCESS="true").
+    # To disable internet access checks, set INTERNET_ACCESS="false".
+    INTERNET_ACCESS: "true"
 
 run:
     steps:
@@ -61,7 +64,7 @@ run:
         - chown testuser:testuser .
         - if echo "${TEST_REBOOT_EXPECTED}" |grep -i "true" ; then ./monitor_fastboot.sh & fi
         - ./monitor_adb.sh &
-        - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}" || if [ $? -eq 100 ]; then error_fatal "The network seems not available, as the ping command failed"; else true; fi
+        - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}" -i "${INTERNET_ACCESS}" || if [ $? -eq 100 ]; then error_fatal "The network seems not available, as the ping command failed"; else true; fi
         # Upload test log and result files to artifactorial.
         - cp -r ./${TEST_PATH}/results ./output/ || true
         - cp -r ./${TEST_PATH}/logs ./output/ || true


### PR DESCRIPTION
For some cases that before the WIFI or ethernet features work on the board,
it would be better to be able to run the cts/vts tests for such devboards too,
regardless of the network related failures.
So adding the INTERNET_ACCESS variable to specify
it it's necessary for the test, default to true
for backwards compatibility