### PR TITLE
noninteractive-tradefed: fix logic of INTERNET_ACCESS check

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.sh
+++ b/automated/android/noninteractive-tradefed/tradefed.sh
@@ -136,7 +136,7 @@ if [ -e "${TEST_PATH}/testcases/vts/testcases/kernel/linux_kselftest/kselftest_c
     sed -i "/suspend/d" "${TEST_PATH}"/testcases/vts/testcases/kernel/linux_kselftest/kselftest_config.py
 fi
 
-if [ "X${INTERNET_ACCESS}" = "Xtrue" ] && [ "X${INTERNET_ACCESS}" = "XTrue" ]; then
+if [ "X${INTERNET_ACCESS}" = "Xtrue" ] || [ "X${INTERNET_ACCESS}" = "XTrue" ]; then
     check_internet_access
 fi
 


### PR DESCRIPTION
it should be OR (||) instead of AND(&&) for the true and True check.