### PR TITLE
automated: linux: kunit: fix return code check

### DIFF
--- a/automated/linux/kunit/kunit.sh
+++ b/automated/linux/kunit/kunit.sh
@@ -63,8 +63,7 @@ rm /tmp/kunit_module_names_not_loaded.txt 2>/dev/null
 # find modules that isn't loaded
 while read -r module; do
     module_name=$(basename "${module}" ".ko")
-    lsmod |grep "${module_name}"
-    if [ $? != "${module_name}" ]; then
+    if ! lsmod | grep "${module_name}"; then
         echo "${module_name}" | tee -a /tmp/kunit_module_names_not_loaded.txt
     fi
 done < "/tmp/kunit_modules.txt"


### PR DESCRIPTION
The check "$?" checks against a string, which isn't correct it should check against a return code.
Rewrote the if-statement to do lsmod | grep.

Reported-by: Yongqin Liu <yongqin.liu@linaro.org>