### PR TITLE
automated: linux: gpiod: parse-output: drop 'tests' prefix

### DIFF
--- a/automated/linux/gpiod/parse-output.py
+++ b/automated/linux/gpiod/parse-output.py
@@ -12,15 +12,14 @@ def slugify(line):
     )
 
 
-tests = ""
 for line in sys.stdin:
     if re.search(r"^.*?not ok \d{1,5} ", line):
         match = re.match(r"^.*?not ok [0-9]+ (.*?)$", line)
         ascii_test_line = slugify(re.sub("# .*$", "", match.group(1)))
-        output = f"{tests}_{ascii_test_line} fail"
+        output = f"{ascii_test_line} fail"
         print(f"{output}")
     elif re.search(r"^ok \d{1,5} ", line):
         match = re.match(r"^.*?ok [0-9]+ (.*?)$", line)
         ascii_test_line = slugify(match.group(1))
-        output = f"{tests}_{ascii_test_line} pass"
+        output = f"{ascii_test_line} pass"
         print(f"{output}")


### PR DESCRIPTION
The output of the test name always starts with a '_' which is wrong. Removing that by remove the prefixed '{tests}_' the testname, and the 'tests' variable was assigned to an empty string. This resulted in that the testname started with a prefix '_'.