### PR TITLE
automated: linux: add alsa-smoke test

### DIFF
--- a/automated/linux/alsa-smoke/alsa-smoke.sh
+++ b/automated/linux/alsa-smoke/alsa-smoke.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+. ../../lib/sh-test-lib
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+export RESULT_FILE
+REFERENCE_PATH="/dev/snd"
+SKIP_INSTALL="False"
+
+usage() {
+    echo "Usage: $0 [-s <true|false>] [-p </path/to/snd/devices>]" 1>&2
+    exit 1
+}
+
+while getopts "s:p:h" o; do
+  case "$o" in
+    s) SKIP_INSTALL="${OPTARG}" ;;
+    p) REFERENCE_PATH="${OPTARG}" ;;
+    h|*) usage ;;
+  esac
+done
+
+install() {
+    dist_name
+    # shellcheck disable=SC2154
+    case "${dist}" in
+      debian|ubuntu) install_deps "alsa-utils" "${SKIP_INSTALL}";;
+      fedora|centos) install_deps "alsa-utils" "${SKIP_INSTALL}";;
+      unknown) warn_msg "Unsupported distro: package install skipped" ;;
+    esac
+}
+
+run() {
+    # shellcheck disable=SC3043
+    local test_command="$1"
+    # shellcheck disable=SC3043
+    local test_name="$2"
+    # shellcheck disable=SC2086
+    if command -v ${test_command}; then
+        # shellcheck disable=SC2086
+        if ${test_command} -l | grep "card [0-9]"; then
+            report_pass "${test_name}_devices"
+        else
+            report_fail "${test_name}_devices"
+        fi
+    else
+        # shellcheck disable=SC2086
+        # shellcheck disable=SC2012
+        DEVICES=$(find ${REFERENCE_PATH} -type c -name "controlC*" | wc -l)
+        if [ "${DEVICES}" -gt 0 ]; then
+            report_pass "${test_name}_devices"
+        else
+            report_fail "${test_name}_devices"
+        fi
+    fi
+}
+
+# Test run.
+create_out_dir "${OUTPUT}"
+
+install
+
+run aplay playback
+run arecord record

--- a/automated/linux/alsa-smoke/alsa-smoke.yaml
+++ b/automated/linux/alsa-smoke/alsa-smoke.yaml
@@ -1,0 +1,28 @@
+metadata:
+    format: Lava-Test Test Definition 1.0
+    name: alsa-smoke
+    description: "Run alsa smoke tests. The test checks if
+      there are playback and record devices available.
+      No actual playback or record tests are performed."
+    maintainer:
+        - milosz.wasilewski@oss.qualcomm.com
+    os:
+        - debian
+        - ubuntu
+        - centos
+        - fedora
+        - openembedded
+    scope:
+        - functional
+    devices:
+        - imx8mm-lpddr4-evk
+
+params:
+    SKIP_INSTALL: "False"
+    REFERENCE_PATH: "/dev/snd"
+
+run:
+    steps:
+        - cd ./automated/linux/alsa-smoke/
+        - ./alsa-smoke.sh -s "${SKIP_INSTALL}" -p "${REFERENCE_PATH}"
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
The test uses alsa-utils tools aplay and arecord to find whether any playback and record devices are available in the system. If the test runs on an OS without package manager and no alsa-utils available it will fall back to look for character devices named "controlCX" where X is a number. This is the same approach that alsa-utils uses. The default path to look for devices is /dev/snd/