### PR TITLE
automated: utils: remove distutils from test-runner

### DIFF
--- a/automated/lib/py_util_lib.py
+++ b/automated/lib/py_util_lib.py
@@ -1,5 +1,4 @@
-"""Shared Python 3 utility code.
-"""
+"""Shared Python 3 utility code."""
 
 from pathlib import Path
 import subprocess

--- a/automated/utils/test-runner.py
+++ b/automated/utils/test-runner.py
@@ -16,7 +16,6 @@ import textwrap
 import time
 from uuid import uuid4
 from datetime import datetime
-from distutils.spawn import find_executable
 
 
 try:
@@ -844,7 +843,7 @@ class ResultParser(object):
             self.results["version"] = test_version.rstrip()
             os.chdir(path)
         self.lava_run = args.lava_run
-        if self.lava_run and not find_executable("lava-test-case"):
+        if self.lava_run and not shutil.which("lava-test-case"):
             self.logger.info(
                 "lava-test-case not found, '-l' or '--lava_run' option ignored'"
             )


### PR DESCRIPTION
distutils package was removed from python3.12. This patch removes distutils from test-runner and replaces it with shutil.