### PR TITLE
automated: linux: ltp: remove kirk's report.json after parsing it

### DIFF
--- a/automated/linux/ltp/ltp.sh
+++ b/automated/linux/ltp/ltp.sh
@@ -193,6 +193,7 @@ run_ltp() {
                                 --json-report /tmp/kirk-report.json \
                                 --verbose" "tee ${OUTPUT}/LTP_${LOG_FILE}.out"
         parse_ltp_json_results "/tmp/kirk-report.json"
+        rm "/tmp/kirk-report.json"
     else
         pipe0_status "./runltp -p -q -f shardfile \
                                  -l ${OUTPUT}/LTP_${LOG_FILE}.log \


### PR DESCRIPTION
When running multiple ltp suites without rebooting, the following error is shown when running kirk the second time:
'kirk: error: JSON report file already exists: /tmp/kirk-report.json'

Remove the kirk-report.json file after parsing the file.