### PR TITLE
automated: linux: Add ALSA basic audio test

### DIFF
--- a/automated/linux/alsa-bat/bat.sh
+++ b/automated/linux/alsa-bat/bat.sh
@@ -1,0 +1,72 @@
+#!/bin/sh -e
+# shellcheck disable=SC1091
+
+OUTPUT="$(pwd)/output"
+RESULT_FILE="${OUTPUT}/result.txt"
+
+. ../../lib/sh-test-lib
+
+create_out_dir "${OUTPUT}"
+
+PARAMS=
+
+if [ "${TST_CARD}" != "" ]; then
+	PARAMS="${PARAMS} -D${TST_CARD}"
+fi
+
+if [ "${TST_CHANNELS}" != "" ]; then
+	PARAMS="${PARAMS} -c${TST_CHANNELS}"
+fi
+
+if [ "${TST_PLAYBACK}" != "" ]; then
+	PARAMS="${PARAMS} -P${TST_PLAYBACK}"
+fi
+
+if [ "${TST_CAPTURE}" != "" ]; then
+	PARAMS="${PARAMS} -C${TST_CAPTURE}"
+fi
+
+if [ "${TST_FORMAT}" != "" ]; then
+	PARAMS="${PARAMS} -f${TST_FORMAT}"
+fi
+
+if [ "${TST_RATE}" != "" ]; then
+	PARAMS="${PARAMS} -r${TST_RATE}"
+fi
+
+if [ "${TST_LENGTH}" != "" ]; then
+	PARAMS="${PARAMS} -n${TST_LENGTH}"
+fi
+
+if [ "${TST_SIGMA_K}" != "" ]; then
+	PARAMS="${PARAMS} -k${TST_SIGMA_K}"
+fi
+
+if [ "${TST_FREQ}" != "" ]; then
+	PARAMS="${PARAMS} -F${TST_FREQ}"
+fi
+
+# Debian installs as alsabat due to name collisions
+if [ "$(command -v alsabat)" != "" ]; then
+	BAT=alsabat
+elif [ "$(command -v bat)" != "" ]; then
+	BAT=bat
+fi
+
+if [ "${BAT}" = "" ]; then
+	echo Unable to find BAT
+	exit 1
+fi
+
+TEST_NAME="$(echo "bat${PARAMS}" | sed 's/ /_/g' | sed 's/-//g')"
+
+# Return code 0 for pass, other codes for various fails
+if ${BAT} ${PARAMS} --log=${OUTPUT}/${TEST_NAME}.log ; then
+	R=pass
+else
+	R=fail
+fi
+
+echo ${TEST_NAME} ${R} >> ${RESULT_FILE}
+
+../../utils/send-to-lava.sh ${RESULT_FILE}

--- a/automated/linux/alsa-bat/bat.yaml
+++ b/automated/linux/alsa-bat/bat.yaml
@@ -1,0 +1,47 @@
+metadata:
+    name: alsabat
+    format: "Lava-Test Test Definition 1.0"
+    description: "Run the ALSA Basic Audio Test"
+    maintainer:
+        - broonie@kernel.org
+    os:
+        - debian
+        - ubuntu
+        - fedora
+        - centos
+        - oe
+    scope:
+        - functional
+    devices:
+        - all
+
+params:
+    # Number of audio channel to use
+    TST_CHANNELS: ""
+
+    # Playback device
+    TST_PLAYBACK: ""
+
+    # Capture device
+    TST_CAPTURE: ""
+
+    # Sample format
+    TST_FORMAT: ""
+
+    # Sample rate
+    TST_RATE: ""
+
+    # Duration of generated signal
+    TST_LENGTH: ""
+
+    # Sigma k for analysis
+    TST_SIGMA_K: ""
+ 
+    # Target frequency
+    TST_FREQ: ""
+
+run:
+    steps:
+        - cd ./automated/linux/alsa-bat
+        - ./bat.sh
+        - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
This is an incredibly basic test, shipped as part of alsa-utils, which
plays and records a tone then uses a FFT to verify that the tone appears
sufficiently cleanly in the output.  It requires that the system under
test have previously been set up with a loopback audio path, either
within the card or via cables.

Signed-off-by: Mark Brown <broonie@kernel.org>
