### PR TITLE
automated: linux: kselftest: fix kselftest log publish

### DIFF
--- a/automated/linux/kselftest/parse-output.py
+++ b/automated/linux/kselftest/parse-output.py
@@ -86,7 +86,7 @@ def make_log_files(results):
         name = r["name"]
         if r["result"] == "fail":
             try:
-                log_file = open(f"output/thisshouldntwork/{name}.log", "w")
+                log_file = open(f"output/{name}.log", "w")
                 log_file.writelines(r["logs"])
                 log_file.close()
             except OSError as e:


### PR DESCRIPTION
In kselftest/parse-output.py a change made for debugging was mistakenly added in a previous commit, which is causing kselftest to not properly create and find extended error log files.

Removes faulty code.