### PR TITLE
automated: linux: ltp: kirk runner: parallelize tests

### DIFF
--- a/automated/linux/ltp/ltp.sh
+++ b/automated/linux/ltp/ltp.sh
@@ -31,6 +31,7 @@ SHARD_NUMBER=1
 SHARD_INDEX=1
 
 RUNNER=""
+KIRK_WORKERS=1
 
 LTP_TMPDIR=/ltp-tmp
 
@@ -58,7 +59,7 @@ usage() {
     exit 0
 }
 
-while getopts "M:T:S:b:d:g:e:i:s:v:R:r:u:p:t:c:n:" arg; do
+while getopts "M:T:S:b:d:g:e:i:s:v:R:r:u:p:t:c:n:w:" arg; do
    case "$arg" in
      T)
         TST_CMDFILES="${OPTARG}"
@@ -135,6 +136,9 @@ while getopts "M:T:S:b:d:g:e:i:s:v:R:r:u:p:t:c:n:" arg; do
      n)
         SHARD_NUMBER="$OPTARG"
         ;;
+     w)
+        KIRK_WORKERS="$OPTARG"
+        ;;
      *)
         usage
         error_msg "No flag ${OPTARG}"
@@ -198,6 +202,7 @@ run_ltp() {
         pipe0_status "${RUNNER} --framework ltp --run-suite shardfile \
                                 -d ${LTP_TMPDIR} --env LTP_COLORIZE_OUTPUT=0 \
                                 ${SKIPFILE_PATH:+--skip-file} ${SKIPFILE_PATH} \
+                                ${KIRK_WORKERS:+--workers} ${KIRK_WORKERS} \
                                 --json-report /tmp/kirk-report.json" \
                                 "tee ${OUTPUT}/LTP_${LOG_FILE}.out"
         parse_ltp_json_results "/tmp/kirk-report.json"

--- a/automated/linux/ltp/ltp.yaml
+++ b/automated/linux/ltp/ltp.yaml
@@ -44,6 +44,10 @@ params:
     # Set RUNNER to full path to kirk or to kirk if its in the PATH.
     RUNNER: ""
 
+    # Number of parallel test workers to use with the new KIRK runner.
+    # # Tests can now run concurrently by specifying '--workers X'.
+    KIRK_WORKERS: 1
+
     # If the following parameter is set, then the LTP suite is
     # cloned and used unconditionally. In particular, the version
     # of the suite is set to the commit pointed to by the
@@ -76,5 +80,5 @@ params:
 run:
     steps:
         - cd ./automated/linux/ltp/
-        - ./ltp.sh -T "${TST_CMDFILES}" -s "${SKIP_INSTALL}" -v "${LTP_VERSION}" -M "${TIMEOUT_MULTIPLIER}" -R "${ROOT_PASSWD}" -r "${RUNNER}" -b "${BOARD}" -d "${LTP_TMPDIR}" -g "${BRANCH}" -e "${ENVIRONMENT}" -i "${LTP_INSTALL_PATH}" -S "${SKIPFILE}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}" -t "${BUILD_FROM_TAR}" -n "${SHARD_NUMBER}" -c "${SHARD_INDEX}"
+        - ./ltp.sh -T "${TST_CMDFILES}" -s "${SKIP_INSTALL}" -v "${LTP_VERSION}" -M "${TIMEOUT_MULTIPLIER}" -R "${ROOT_PASSWD}" -r "${RUNNER}" -b "${BOARD}" -d "${LTP_TMPDIR}" -g "${BRANCH}" -e "${ENVIRONMENT}" -i "${LTP_INSTALL_PATH}" -S "${SKIPFILE}" -p "${TEST_DIR}" -u "${TEST_GIT_URL}" -t "${BUILD_FROM_TAR}" -n "${SHARD_NUMBER}" -c "${SHARD_INDEX}" -w "${KIRK_WORKERS}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Add support for parallel test execution with the new LTP test runner, kirk.  This update introduces the KIRK_WORKERS variable, which allows you to configure the number of worker processes used for running tests in parallel. This can significantly reduce test runtime on systems with many CPU cores.

Suggested-by: Mark Brown <broonie@kernel.org>