### PR TITLE
Add generic pass/fail logic to rt-tests: cyclicdeadline, pi_stress

### DIFF
--- a/automated/linux/cyclicdeadline/cyclicdeadline.sh
+++ b/automated/linux/cyclicdeadline/cyclicdeadline.sh
@@ -68,3 +68,45 @@ for i in $(seq ${ITERATIONS}); do
     fi
     cat "${TMP_RESULT_FILE}" | tee -a "${RESULT_FILE}"
 done
+
+if [ "${ITERATIONS}" -gt 2 ]; then
+    max_latencies_file="${OUTPUT}/max_latencies.txt"
+
+    # Extract all max-latency values into a file
+    grep "max-latency" "${RESULT_FILE}" | grep "^iteration-" | awk '{ print $(NF-1) }' |tee "${max_latencies_file}"
+
+    if [ ! -s "${max_latencies_file}" ]; then
+        echo "No max-latency values found!"
+        report_fail "rt-tests-cyclicdeadline"
+        exit 1
+    fi
+
+    # Find the minimum latency
+    min_latency=$(sort -n "${max_latencies_file}" | head -n1)
+
+    threshold=$(echo "$min_latency * 1.10" | bc -l)
+
+    echo "Minimum max latency: $min_latency"
+    echo "Threshold (min * 1.10): $threshold"
+
+    # Count how many latencies exceed threshold
+    fail_count=0
+    while read -r val; do
+        is_greater=$(echo "$val > $threshold" | bc -l)
+        if [ "$is_greater" -eq 1 ]; then
+            fail_count=$((fail_count + 1))
+        fi
+    done < "${max_latencies_file}"
+
+    fail_limit=$((ITERATIONS / 2))
+
+    echo "Max allowed failures: $fail_limit"
+    echo "Actual failures: $fail_count"
+    echo "Number of max latencies above 110% of min: $fail_count"
+
+    if [ "$fail_count" -ge "$fail_limit" ]; then
+        report_fail "rt-tests-cyclicdeadline"
+    else
+        report_pass "rt-tests-cyclicdeadline"
+    fi
+fi

--- a/automated/linux/cyclicdeadline/cyclicdeadline.sh
+++ b/automated/linux/cyclicdeadline/cyclicdeadline.sh
@@ -17,13 +17,14 @@ THREADS="1"
 DURATION="1m"
 BACKGROUND_CMD=""
 ITERATIONS=1
+PTHRESHOLD="10"
 
 usage() {
-    echo "Usage: $0 [-i interval] [-s step] [-t threads] [-D duration ] [-w background_cmd] [-I iterations]" 1>&2
+    echo "Usage: $0 [-i interval] [-s step] [-t threads] [-D duration ] [-w background_cmd] [-I iterations] [-p procent threshold]" 1>&2
     exit 1
 }
 
-while getopts ":i:s:t:D:w:I:" opt; do
+while getopts ":i:s:t:D:w:I:p:" opt; do
     case "${opt}" in
         i) INTERVAL="${OPTARG}" ;;
         s) STEP="${OPTARG}" ;;
@@ -31,6 +32,7 @@ while getopts ":i:s:t:D:w:I:" opt; do
         D) DURATION="${OPTARG}" ;;
         w) BACKGROUND_CMD="${OPTARG}" ;;
         I) ITERATIONS="${OPTARG}" ;;
+        p) PTHRESHOLD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -84,10 +86,11 @@ if [ "${ITERATIONS}" -gt 2 ]; then
     # Find the minimum latency
     min_latency=$(sort -n "${max_latencies_file}" | head -n1)
 
-    threshold=$(echo "$min_latency * 1.10" | bc -l)
+    echo "PTHRESHOLD: ${PTHRESHOLD}"
+    threshold=$(echo "$min_latency * (1.${PTHRESHOLD})" | bc -l)
 
     echo "Minimum max latency: $min_latency"
-    echo "Threshold (min * 1.10): $threshold"
+    echo "Threshold: $threshold in procent 1.$PTHRESHOLD"
 
     # Count how many latencies exceed threshold
     fail_count=0
@@ -102,7 +105,7 @@ if [ "${ITERATIONS}" -gt 2 ]; then
 
     echo "Max allowed failures: $fail_limit"
     echo "Actual failures: $fail_count"
-    echo "Number of max latencies above 110% of min: $fail_count"
+    echo "Number of max latencies above 1.${PTHRESHOLD}% of min: $fail_count"
 
     if [ "$fail_count" -ge "$fail_limit" ]; then
         report_fail "rt-tests-cyclicdeadline"

--- a/automated/linux/cyclicdeadline/cyclicdeadline.yaml
+++ b/automated/linux/cyclicdeadline/cyclicdeadline.yaml
@@ -46,10 +46,11 @@ params:
     ARTIFACTORIAL_URL: "https://archive.validation.linaro.org/artifacts/team/qa/"
     ARTIFACTORIAL_TOKEN: ""
     ITERATIONS: 1
+    PTHRESHOLD: "10"
 
 run:
     steps:
         - cd ./automated/linux/cyclicdeadline/
-        - ./cyclicdeadline.sh -i "${INTERVAL}" -s "${STEP}" -t "${THREADS}" -D "${DURATION}" -I "${ITERATIONS}" -w "${BACKGROUND_CMD}"
+        - ./cyclicdeadline.sh -i "${INTERVAL}" -s "${STEP}" -t "${THREADS}" -D "${DURATION}" -I "${ITERATIONS}" -w "${BACKGROUND_CMD}" -p "${PTHRESHOLD}"
         - ../../utils/upload-to-artifactorial.sh -a "output/cyclicdeadline.json" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"
         - ../../utils/send-to-lava.sh ./output/result.txt

--- a/automated/linux/pi-stress/pi-stress.sh
+++ b/automated/linux/pi-stress/pi-stress.sh
@@ -17,19 +17,21 @@ MLOCKALL="false"
 RR="false"
 BACKGROUND_CMD=""
 ITERATIONS=1
+PTHRESHOLD="10"
 
 usage() {
-    echo "Usage: $0 [-D runtime] [-m <true|false>] [-r <true|false>] [-w background_cmd] [-i iterations]" 1>&2
+    echo "Usage: $0 [-D runtime] [-m <true|false>] [-r <true|false>] [-w background_cmd] [-i iterations] [-p procent threshold]" 1>&2
     exit 1
 }
 
-while getopts ":D:m:r:w:i:" opt; do
+while getopts ":D:m:r:w:i:p:" opt; do
     case "${opt}" in
         D) DURATION="${OPTARG}" ;;
         m) MLOCKALL="${OPTARG}" ;;
         r) RR="${OPTARG}" ;;
         w) BACKGROUND_CMD="${OPTARG}" ;;
         i) ITERATIONS="${OPTARG}" ;;
+        p) PTHRESHOLD="${OPTARG}" ;;
         *) usage ;;
     esac
 done
@@ -92,10 +94,11 @@ if [ "${ITERATIONS}" -gt 2 ]; then
     # Find the minimum inversion
     min_inversion=$(sort -n "${max_inversions_file}" | head -n1)
 
-    threshold=$(echo "$min_inversion * 1.10" | bc -l)
+    echo "PTHRESHOLD: ${PTHRESHOLD}"
+    threshold=$(echo "$min_inversion * (1.${PTHRESHOLD})" | bc -l)
 
     echo "Minimum max inversion: $min_inversion"
-    echo "Threshold (min * 1.10): $threshold"
+    echo "Threshold: $threshold in procent 1.$PTHRESHOLD"
 
     # Count how many inversions exceed threshold
     fail_count=0
@@ -110,7 +113,7 @@ if [ "${ITERATIONS}" -gt 2 ]; then
 
     echo "Max allowed failures: $fail_limit"
     echo "Actual failures: $fail_count"
-    echo "Number of max inversions above 110% of min: $fail_count"
+    echo "Number of max inversions above 1.${PTHRESHOLD}% of min: $fail_count"
 
     if [ "$fail_count" -ge "$fail_limit" ]; then
         report_fail "rt-tests-pi-stress"

--- a/automated/linux/pi-stress/pi-stress.yaml
+++ b/automated/linux/pi-stress/pi-stress.yaml
@@ -41,10 +41,11 @@ params:
     ARTIFACTORIAL_URL: "https://archive.validation.linaro.org/artifacts/team/qa/"
     ARTIFACTORIAL_TOKEN: ""
     ITERATIONS: 1
+    PTHRESHOLD: "10"
 
 run:
     steps:
         - cd automated/linux/pi-stress
-        - ./pi-stress.sh -D "${DURATION}" -m "${MLOCKALL}" -r "${RR}" -i "${ITERATIONS}" -w "${BACKGROUND_CMD}"
+        - ./pi-stress.sh -D "${DURATION}" -m "${MLOCKALL}" -r "${RR}" -i "${ITERATIONS}" -w "${BACKGROUND_CMD}" -p "${PTHRESHOLD}"
         - ../../utils/upload-to-artifactorial.sh -a "output/pi-stress.json" -u "${ARTIFACTORIAL_URL}" -t "${ARTIFACTORIAL_TOKEN}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
This pull request introduces enhancements to the rt-tests suite by adding generic pass/fail logic to the following tests: cyclicdeadline, pi_stress.

Key Changes:
* Generic Pass/Fail Logic: A standardized evaluation mechanism has been implemented to determine test success or failure based on a predefined threshold (PTHRESHOLD, expressed in percent).

* Improved Result Reporting: Output now clearly indicates whether a test has passed or failed, while also preserving the original test output. This makes it easier to analyze test behavior and detect anomalies or regressions.
