### PR TITLE
automated: linux: add more options to docker networking

### DIFF
--- a/automated/lib/sh-test-lib
+++ b/automated/lib/sh-test-lib
@@ -102,15 +102,16 @@ exit_on_skip() {
 check_return() {
     # shellcheck disable=SC2039
     local exit_code="$?"
-    [ "$#" -ne 1 ] && error_msg "Usage: check_return test_case"
+    [ "$#" -lt 1 ] && error_msg "Usage: check_return test_case [xfail]"
     # shellcheck disable=SC2039
     local test_case="$1"
+    local xfail="${2:-}"
 
-    if [ "${exit_code}" -ne 0 ]; then
-        echo "${test_case} fail" | tee -a "${RESULT_FILE}"
+    if [ "${exit_code}" -ne 0 ] && [ -z "${xfail}" ]; then
+        report_fail "${test_case}"
         return "${exit_code}"
     else
-        echo "${test_case} pass" | tee -a "${RESULT_FILE}"
+        report_pass "${test_case}"
         return 0
     fi
 }

--- a/automated/lib/sh-test-lib
+++ b/automated/lib/sh-test-lib
@@ -238,7 +238,7 @@ dist_name() {
     fi
 
     # convert dist to lower case
-    dist=$(echo ${dist} | tr '[:upper:]' '[:lower:]')
+    dist=$(echo "${dist}" | tr '[:upper:]' '[:lower:]')
     case "${dist}" in
         rpb*) dist="oe-rpb" ;;
     esac
@@ -337,7 +337,6 @@ validate_check_sum() {
     if [ "$#" -ne 2 ]; then
         warn_msg "The number of parameters should be 2"
         error_msg "Usage: validate_check_sum filename known_sha256sum"
-        return 1
     fi
     # shellcheck disable=SC2039
     local OUTPUT_FILE_NAME="$1"

--- a/automated/linux/docker-networking/docker-networking.sh
+++ b/automated/linux/docker-networking/docker-networking.sh
@@ -7,16 +7,23 @@ RESULT_FILE="${OUTPUT}/result.txt"
 export RESULT_FILE
 IMAGE="alpine:latest"
 SKIP_INSTALL="True"
+NETWORK_TYPE="bridge"
+HOST_INTERFACE="eth0"
 
 usage() {
-    echo "$0 [-i <image>] [-s true|false]" 1>&2
+    echo "$0 [-i <image>] [-n <bridge|host|none>] [-s true|false] [-b eth0]" 1>&2
+    echo "    -n option can be a combination of bridge, host and none." 1>&2
+    echo "       Options should be space separated." 1>&2
+    echo "       In case there are more than one, all tests will be executed." 1>&2
     exit 1
 }
 
-while getopts "i:s:h" o; do
+while getopts "i:s:n:b:h" o; do
     case "$o" in
         i) IMAGE="${OPTARG}" ;;
         s) SKIP_INSTALL="${OPTARG}";;
+        n) NETWORK_TYPE="${OPTARG}";;
+        b) HOST_INTERFACE="${OPTARG}";;
         h|*) usage ;;
     esac
 done
@@ -43,48 +50,77 @@ install_docker() {
     esac
 }
 
+remove_one_from_skiplist() {
+    echo "$1" | cut -f2- -d" "
+}
+
 if [ "${SKIP_INSTALL}" = "True" ] || [ "${SKIP_INSTALL}" = "true" ]; then
     info_msg "Installation skipped"
 else
     install_docker
 fi
+
+HOST_IP=$(ip addr show dev "${HOST_INTERFACE}" | grep "inet " | awk '{ print $2 }' | awk -F "/" '{print $1}')
+
 # verify that docker is available
-skip_list="docker-network-list docker-start-container docker-network-inspect docker-network-bridge ping-container-test docker-kill-container docker-ping-localhost-host-network"
+for NETWORK in ${NETWORK_TYPE}; do
+    skip_list="${skip_list} docker-network-list-${NETWORK} docker-start-container-${NETWORK} docker-network-inspect-${NETWORK} docker-network-${NETWORK} ping-container-test-${NETWORK} docker-kill-container-${NETWORK} docker-ping-host-network-${NETWORK}"
+done
 docker --version
 exit_on_fail "docker-version" "${skip_list}"
 
-# check if bridge network is present
-skip_list="docker-start-container docker-network-inspect docker-network-bridge ping-container-test docker-kill-container docker-ping-localhost-host-network"
-docker network ls -f name=bridge | grep bridge
-exit_on_fail "docker-network-list" "${skip_list}"
+for NETWORK in ${NETWORK_TYPE}; do
+    # check if bridge network is present
+    skip_list=$(remove_one_from_skiplist "${skip_list}")
+    docker network ls -f name="${NETWORK}" | grep "${NETWORK}"
+    exit_on_fail "docker-network-list" "${skip_list}"
 
-# start simple alpine container
-skip_list="docker-network-inspect docker-network-bridge ping-container-test docker-kill-container docker-ping-localhost-host-network"
-docker run --name ping_test_container --rm -d "${IMAGE}" /bin/sleep 90
-exit_on_fail "docker-start-container" "${skip_list}"
+    # start simple alpine container
+    skip_list=$(remove_one_from_skiplist "${skip_list}")
+    docker run --name ping_test_container --network "${NETWORK}" --rm -d "${IMAGE}" /bin/sleep 90
+    exit_on_fail "docker-start-container" "${skip_list}"
 
-# container should join bridge network
-skip_list="docker-network-bridge ping-container-test docker-kill-container docker-ping-localhost-host-network"
-DOCKER_INSPECT=$(docker network inspect bridge)
-exit_on_fail "docker-network-inspect" "${skip_list}"
+    # container should join NETWORK network
+    skip_list=$(remove_one_from_skiplist "${skip_list}")
+    DOCKER_INSPECT=$(docker network inspect "${NETWORK}")
+    exit_on_fail "docker-network-inspect-${NETWORK}" "${skip_list}"
 
-echo "$DOCKER_INSPECT" | jq '.[0]["Containers"][]'
-IP_ADDR=$(echo "$DOCKER_INSPECT" | jq '.[0]["Containers"][] | select(.Name=="ping_test_container") | .IPv4Address | split("/")[0]')
-echo "${IP_ADDR}"
-if [ -n "$IP_ADDR" ]; then
-    report_pass "docker-network-bridge"
-    eval "ping -c4 $IP_ADDR"
-    check_return "ping-container-test"
-else
-    report_fail "docker-network-bridge"
-    report_skip "ping-container-test"
-fi
+    skip_list=$(remove_one_from_skiplist "${skip_list}")
+    if [ "${NETWORK}" = "bridge" ]; then
+        echo "$DOCKER_INSPECT" | jq '.[0]["Containers"][]'
+        IP_ADDR=$(echo "$DOCKER_INSPECT" | jq '.[0]["Containers"][] | select(.Name=="ping_test_container") | .IPv4Address | split("/")[0]')
+        echo "${IP_ADDR}"
+        if [ -n "$IP_ADDR" ]; then
+            report_pass "docker-network-${NETWORK}"
+            eval "ping -c4 $IP_ADDR"
+            skip_list=$(remove_one_from_skiplist "${skip_list}")
+            check_return "ping-container-test-${NETWORK}"
+        else
+            report_fail "docker-network-${NETWORK}"
+            skip_list=$(remove_one_from_skiplist "${skip_list}")
+            report_skip "ping-container-test-${NETWORK}"
+        fi
+    else
+        report_pass "docker-network-${NETWORK}"
+        skip_list=$(remove_one_from_skiplist "${skip_list}")
+        report_skip "ping-container-test-${NETWORK}"
+    fi
+    skip_list=$(remove_one_from_skiplist "${skip_list}")
+    docker kill ping_test_container
+    check_return "docker-kill-container-${NETWORK}"
 
-docker kill ping_test_container
-check_return "docker-kill-container"
-
-# IPv4 try pinging localhost from container with host networking
-docker run --name ping_localhost_host_network --rm -d "${IMAGE}" ping -4 -c 4 localhost
-check_return "docker-ping-localhost-host-network"
+    skip_list=$(remove_one_from_skiplist "${skip_list}")
+    if [ -n "${HOST_IP}" ]; then
+        xfail=""
+        if [ "${NETWORK}" = none ]; then
+            # ping should fail with disabled networking
+            xfail="xfail"
+        fi
+        docker run --name ping_localhost_host_network --network "${NETWORK}" --rm "${IMAGE}" ping -4 -c 4 "${HOST_IP}"
+        check_return "docker-ping-host-network-${NETWORK}" "${xfail}"
+    else
+        report_skip "docker-ping-host-network-${NETWORK}"
+    fi
+done
 
 exit 0

--- a/automated/linux/docker-networking/docker-networking.yaml
+++ b/automated/linux/docker-networking/docker-networking.yaml
@@ -26,9 +26,13 @@ params:
     # Docker image.
     IMAGE: "alpine:latest"
     SKIP_INSTALL: "true"
+    # NETWORK can be any of "bridge", "host", "none"
+    # or it can be a combination of them, like "bridge host"
+    NETWORK: "bridge"
+    HOST_INTERFACE: "eth0"
 
 run:
     steps:
         - cd ./automated/linux/docker-networking/
-        - ./docker-networking.sh -i "${IMAGE}" -s "${SKIP_INSTALL}"
+        - ./docker-networking.sh -i "${IMAGE}" -s "${SKIP_INSTALL}" -n "${NETWORK}" -b "${HOST_INTERFACE}"
         - ../../utils/send-to-lava.sh ./output/result.txt


### PR DESCRIPTION
Add "host" and "none" network options to docker-networking tests. This allows to cover all simple possibilities when it comes to docker networking. All tests can be executed in one run by adding -n option to the script invocation. Example:

    docker-networking.sh -n "bridge host"

Test names were appended with ${NETWORK} to indicate which network type is tested. Default is "bridge".