### PR TITLE
automated: linux: kselftest: Deduplicate test names with minuses

### DIFF
--- a/automated/linux/kselftest/parse-output.py
+++ b/automated/linux/kselftest/parse-output.py
@@ -8,7 +8,7 @@ def slugify(line):
     non_ascii_pattern = r"[^A-Za-z0-9_-]+"
     line = re.sub(r"\[\d{1,5}\]", "", line)
     return re.sub(
-        r"_-", "_", re.sub(r"(^_|_$)", "", re.sub(non_ascii_pattern, "_", line))
+        r"_-", "__", re.sub(r"(^_|_$)", "", re.sub(non_ascii_pattern, "_", line))
     )
 
 


### PR DESCRIPTION
Currently the KTAP output parser deletes any '-' it sees in the test
name when slugifying it.  This means that in a case like the arm64
breakpoints test two distinct tests end up squashed into the same name
since the only difference in name is a minus sign:

 ok 1 Test size = 1 write offset = 0 watchpoint offset = -1
 ok 3 Test size = 1 write offset = 0 watchpoint offset = 1

becomes:

breakpoints_breakpoint_test_arm64_Test_size_1_write_offset_0_watchpoint_offset_1 pass
breakpoints_breakpoint_test_arm64_Test_size_1_write_offset_0_watchpoint_offset_1_dup2 pass

which isn't ideal.  Fix this by converting the '-' to an '_' instead.

Signed-off-by: Mark Brown <broonie@kernel.org>
