### PR TITLE
automated: linux: kselftest: filter skip entries by subsuite

### DIFF
--- a/automated/linux/kselftest/kselftest.sh
+++ b/automated/linux/kselftest/kselftest.sh
@@ -189,9 +189,18 @@ cp kselftest-list.txt kselftest-list.txt.orig
 echo "skiplist:"
 echo "========================================"
 while read -r skip_regex; do
-    echo "$skip_regex"
-    # Remove matching tests from list of tests to run and report it as skipped
-    perl -i -ne 'if (s|^('"${skip_regex}"')$|\1 skip|) { print STDERR; } else { print; }' kselftest-list.txt 2>>"${RESULT_FILE}"
+    subsuite="${skip_regex%%:*}"
+
+    # Loop through each subsuite in TST_CMDFILES and compare
+    for selected in ${TST_CMDFILES}; do
+        if [ "${subsuite}" = "${selected}" ]; then
+            echo "$skip_regex"
+            # Remove matching tests from list of tests to run and report it as skipped
+            perl -i -ne 'if (s|^('"${skip_regex}"')$|\1 skip|) { print STDERR; } else { print; }' \
+                kselftest-list.txt 2>>"${RESULT_FILE}"
+            break
+        fi
+    done
 done < "${skips}"
 echo "========================================"
 rm -f "${skips}"


### PR DESCRIPTION
When running a subset of kselftest suites (e.g. kselftest-mm), the existing skipfile logic still applies all entries from skipfile-lkft.yaml, including those unrelated to the selected subsuites. As a result, irrelevant tests (such as those from the breakpoints suite) appear as "skip" in result.json, even though they were not part of the test run.

To ensure accurate skip handling, the logic has been updated so that skip entries only apply to tests within the subsuites selected for the current run. Each skip entry is parsed to extract the subsuite name, which is then compared against the entries in TST_CMDFILES. Skip rules are applied only when a match is found, preventing unrelated tests from appearing as "skipped" in the results.

This avoids polluting results with unrelated test cases and makes skips more accurate and meaningful.