### PR TITLE
automated: linux: ltp: Allow detection of the number of CPUs at runtime

### DIFF
--- a/automated/linux/ltp/ltp.sh
+++ b/automated/linux/ltp/ltp.sh
@@ -199,6 +199,9 @@ run_ltp() {
         if [ $? -ne "0" ]; then
           error_msg "${RUNNER} is not installed into the file system."
         fi
+        if [ "${KIRK_WORKERS}" = "max" ]; then
+          KIRK_WORKERS=$(grep ^processor /proc/cpuinfo | wc -l)
+        fi
         pipe0_status "${RUNNER} --framework ltp --run-suite shardfile \
                                 -d ${LTP_TMPDIR} --env LTP_COLORIZE_OUTPUT=0 \
                                 ${SKIPFILE_PATH:+--skip-file} ${SKIPFILE_PATH} \


### PR DESCRIPTION
Currently the number of kirk workers has to be configured explicitly,
kirk itself does not support detecting the number of CPUs the system has
and test-definitions just passes the value it has straight through to
the kirk runner.  This is a bit annoying when using templating to share
job definitions over multiple device types, requiring explicit per type
configuration.

Given that a very common case is going to be to use all the CPUs
available on the target platform provide support for the magic number of
workers "max" which counts the number of CPUs reported by /proc/cpuinfo
and uses that as the number of workers.

Signed-off-by: Mark Brown <broonie@kernel.org>
