### PR TITLE
automated: linux: ltp: Disable colour output from kirk

### DIFF
--- a/automated/linux/ltp/ltp.sh
+++ b/automated/linux/ltp/ltp.sh
@@ -206,6 +206,7 @@ run_ltp() {
                                 -d ${LTP_TMPDIR} --env LTP_COLORIZE_OUTPUT=0 \
                                 ${SKIPFILE_PATH:+--skip-file} ${SKIPFILE_PATH} \
                                 ${KIRK_WORKERS:+--workers} ${KIRK_WORKERS} \
+				--no-colors \
                                 --json-report /tmp/kirk-report.json" \
                                 "tee ${OUTPUT}/LTP_${LOG_FILE}.out"
         parse_ltp_json_results "/tmp/kirk-report.json"


### PR DESCRIPTION
By default kirk produces colourised output which results in escape
sequences going into the console log.  Since the primary use of
test-definitions is automated this isn't terribly useful and results in
logs that are harder to read.  Pass the --no-colors option to disable
this output.

Signed-off-by: Mark Brown <broonie@kernel.org>
