### PR TITLE
automated: linux: ltp: Speed up parsing of JSON results

### DIFF
--- a/automated/linux/ltp/ltp.sh
+++ b/automated/linux/ltp/ltp.sh
@@ -165,14 +165,9 @@ parse_ltp_output() {
 }
 
 parse_ltp_json_results() {
-    local result
     jq -r '.results| .[]| "\(.test_fqn) \(.test.result)"'  "$1" \
         | sed 's/brok/fail/; s/conf/skip/'  >> "${RESULT_FILE}"
-    for test_fqn in $(jq -r '.results| .[]| .test_fqn' "$1"); do
-      result="$(jq -r '.results | .[] | select(.test_fqn == "'"${test_fqn}"'") | .test.result' "$1")"
-      if [ "${result}" = pass ]; then
-        continue
-      fi
+    for test_fqn in $(jq -r '.results| .[]| select(.test.result != "pass") | .test_fqn' "$1"); do
       jq -r '.results | .[] | select(.test_fqn == "'"${test_fqn}"'") | .test.log' "$1" > ${OUTPUT}/${test_fqn}.log
     done
 }


### PR DESCRIPTION
When parsing the JSON output from kirk we capture any logs that were
generated for tests that didn't pass.  Currently we do this by first
invoking jq to generate a list of tests that were run, then for each
test invoke jq again to check if the result was a pass or not.  If the
result wasn't a pass we then invoke jq again to get the log.  This is
wildly inefficient, we invoke a new copy of jq and parse the entire
results file once per test on the test system in order to generate a
list of tests that didn't pass (which will hopefully be much shorter
than the list of those that fails).

Fortunately jq is capable of directly generating the list of non-passing
tests so we can do a single parse for the initial filter, update to do
that.  We still invoke jq again to generate the log files, these are all
written into per-test files for reporting, but most of the time most
tests should pass.

With the existing implementation for the syscalls suite on an Avenger96
the results parsing takes longer than running the actual tests,
currently it takes over an hour and 20 minutes for the full job but with
this change that time is reduced to a bit under 50 minutes.
Approximately 35 minutes of the jobs is taken running the tests so the
actual parsing is about twice as fast, there are a lot of failures in
these jobs and the benefits should be greater with a higher pass rate.

Signed-off-by: Mark Brown <broonie@kernel.org>
