### PR TITLE
automated: utils: use LAVA_SIGNAL in send-to-lava.sh

### DIFF
--- a/automated/utils/send-to-lava.sh
+++ b/automated/utils/send-to-lava.sh
@@ -40,7 +40,7 @@ if [ -f "${RESULT_FILE}" ]; then
             if [ "${lava_test_case}" -eq 0 ]; then
                 lava-test-case "${test}" --result "${result}"
             else
-                echo "<TEST_CASE_ID=${test} RESULT=${result}>"
+                signal "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=${test} RESULT=${result}>"
             fi
         elif echo "${line}" | grep -iq -E ".*+ (pass|fail|skip|unknown)+ .*+"; then
             test="$(echo "${line}" | awk '{print $1}')"
@@ -56,7 +56,7 @@ if [ -f "${RESULT_FILE}" ]; then
                     lava-test-case "${test}" --result "${result}" --measurement "${measurement}"
                 fi
             else
-               echo "<TEST_CASE_ID=${test} RESULT=${result} MEASUREMENT=${measurement} UNITS=${units}>"
+               signal "<LAVA_SIGNAL_TESTCASE TEST_CASE_ID=${test} RESULT=${result} MEASUREMENT=${measurement} UNITS=${units}>"
             fi
         elif echo "${line}" | grep -iq -E "^lava-test-set.*"; then
             test_set_status="$(echo "${line}" | awk '{print $2}')"


### PR DESCRIPTION
When send-to-lava.sh is used with lava-test-case absent the strings generated in the script were not matching expected LAVA patterns. This patch fixes the pattern and moves the output to signal() function to respect KMSG setting in the lava-test-shell.