### PR TITLE
noninteractive-tradefed: export HTTP_CACHE for tradefed.sh

### DIFF
--- a/automated/android/noninteractive-tradefed/tradefed.yaml
+++ b/automated/android/noninteractive-tradefed/tradefed.yaml
@@ -66,7 +66,7 @@ run:
         - chown testuser:testuser .
         - if echo "${TEST_REBOOT_EXPECTED}" |grep -i "true" ; then ./monitor_fastboot.sh & fi
         - ./monitor_adb.sh &
-        - sudo -u testuser ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}" -i "${INTERNET_ACCESS}" -x "${ENABLE_XTS_DYNAMIC_DOWNLOADER}"|| if [ $? -eq 100 ]; then error_fatal "The network seems not available, as the ping command failed"; else true; fi
+        - sudo -u testuser HTTP_CACHE="${HTTP_CACHE}" ./tradefed.sh  -o "${TIMEOUT}" -c "${TEST_URL}" -t "${TEST_PARAMS}" -p "${TEST_PATH}" -r "${RESULTS_FORMAT}" -n "${ANDROID_SERIAL}" -f "${FAILURES_PRINTED}" -a "${AP_SSID}" -k "${AP_KEY}" -i "${INTERNET_ACCESS}" -x "${ENABLE_XTS_DYNAMIC_DOWNLOADER}"|| if [ $? -eq 100 ]; then error_fatal "The network seems not available, as the ping command failed"; else true; fi
         # Upload test log and result files to artifactorial.
         - cp -r ./${TEST_PATH}/results ./output/ || true
         - cp -r ./${TEST_PATH}/logs ./output/ || true


### PR DESCRIPTION
HTTP_CACHE is one job level environment, but the tradefed.sh script is excuted with the testuser account via
    sudo -u testuser ./tradefed.sh

which causes a issue that the HTTP_CACHE environment is not passed to the ./tradefed.sh script.

Hence this fix to to pass it explicitly.