### PR TITLE
noninteractive-tradefed: drop function for bash function definition i…

### DIFF
--- a/automated/android/noninteractive-tradefed/setup.sh
+++ b/automated/android/noninteractive-tradefed/setup.sh
@@ -5,7 +5,7 @@
 . ../../lib/sh-test-lib
 . ../../lib/android-test-lib
 
-function get_required_java_version() {
+get_required_java_version() {
     local android_version="${1}"
     case "${android_version}" in
         *android11*|*android12*|*android13*) echo "11" ;;


### PR DESCRIPTION
…n setup.sh

which causes the following error:
    /lava-8362303/3/tests/3_cts-lkft/run.sh: 8: ./setup.sh: Syntax error: "(" unexpected

As lava does not use bash to run the script by default, and the function keyword is not recognized.