### PR TITLE
github: workflows: remove test-definitions prefix from zstd-release archives

### DIFF
--- a/.github/workflows/zstd-release.yml
+++ b/.github/workflows/zstd-release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Create .tar.zst archives using git archive
         run: |
-          git archive --format=tar --prefix=test-definitions/ ${{ steps.version.outputs.tag_name }} \
+          git archive --format=tar ${{ steps.version.outputs.tag_name }} \
             | zstd -o ../${{ steps.version.outputs.tag_name }}.tar.zst
           cp ../${{ steps.version.outputs.tag_name }}.tar.zst ../${{ steps.version.outputs.short_tag }}.tar.zst
 


### PR DESCRIPTION

Remove --prefix=test-definitions/ from git archive to create cleaner tar.zst archives without the directory wrapper.

LAVA assumes you don't have the directory wrapper.