### PR TITLE
feat: send output.xml to fileserver for further processing

### DIFF
--- a/automated/linux/torizon/integration-tests.sh
+++ b/automated/linux/torizon/integration-tests.sh
@@ -43,7 +43,7 @@ python3 -m venv venv
 . venv/bin/activate
 pip3 install -r requirements.txt
 
-export SPIRE_PAT_TOKEN LAVA_TOKEN LAVA_PASSWORD
+export SPIRE_PAT_TOKEN LAVA_TOKEN LAVA_PASSWORD SSH_KEY
 
 # run tests
 robot --pythonpath . --exclude gitlab_pipeline --variable remote:"$IS_REMOTE" --outputdir=.. test/

--- a/automated/linux/torizon/integration-tests.yaml
+++ b/automated/linux/torizon/integration-tests.yaml
@@ -32,5 +32,5 @@ params:
 run:
     steps:
         - cd ./automated/linux/torizon/
-        - export IS_REMOTE BAKFLEET_URL BAKLAWEB_URL SPIRE_USER_EMAIL LAVA_USERNAME LAVA_URL ORG_UUID BRANCH_NAME
+        - export IS_REMOTE BAKFLEET_URL BAKLAWEB_URL SPIRE_USER_EMAIL LAVA_USERNAME LAVA_URL ORG_UUID BRANCH_NAME SSH_KEY
         - ./integration-tests.sh

--- a/automated/utils/parse-robot-framework.py
+++ b/automated/utils/parse-robot-framework.py
@@ -2,9 +2,15 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (C) 2024 Linaro Ltd.
 
+import io
+import os
 import argparse
-import subprocess
+
+from datetime import datetime
+
+from paramiko import SSHClient, AutoAddPolicy, RSAKey
 from robot.api import ExecutionResult, ResultVisitor
+from scp import SCPClient
 
 
 def parse_args():
@@ -20,8 +26,39 @@ def parse_args():
     return args
 
 
+def send_output(result_file):
+    print("connecting to ssh server...")
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    server = "people.linaro.org"
+    username = "pawel.szymaszek"
+    pkey = RSAKey.from_private_key(io.StringIO(os.getenv("SSH_KEY")))
+
+    with SSHClient() as ssh:
+        try:
+            ssh.set_missing_host_key_policy(AutoAddPolicy())
+            ssh.connect(hostname=server, username=username, pkey=pkey)
+        except Exception as ex:
+            print(
+                f"Failed to make SSH connection to server due to the following exception: {ex}"
+            )
+
+        with SCPClient(ssh.get_transport()) as scp:
+            try:
+                scp.put(
+                    result_file,
+                    f"~/public_html/remote_robot_dash/output-{timestamp}.xml",
+                )
+                print(f"file {result_file} sent to fileserver")
+            except Exception as ex:
+                print(
+                    f"Failed to send {result_file} to server due to the following exception: {ex}"
+                )
+
+
 def main():
     result = ExecutionResult(args.result_file)
+
+    send_output(args.result_file)
 
     def get_all_tests(suite):
         for test in suite.tests:


### PR DESCRIPTION
In order to create a robotframework dashboard for laa remote testing, we need an output.xml file.
One way to extract it from lava is to upload it to the fileserver using the `parse-robot-framework.py` script.

For temporary solution  personal fileserver was choosen, before we decide how to handle those files in more sustainable way.