### PR TITLE
fix: add ssh variables to def params

### DIFF
--- a/automated/linux/torizon/integration-tests.yaml
+++ b/automated/linux/torizon/integration-tests.yaml
@@ -28,6 +28,9 @@ params:
     SPIRE_PAT_TOKEN: ""
     ORG_UUID: ""
     BRANCH_NAME: "main"
+    SSH_KEY: ""
+    SSH_SERVER: ""
+    SSH_USERNAME: ""
 
 run:
     steps:


### PR DESCRIPTION
Add missing ssh env vars to params so they could be found on lava integration test jobs