### PR TITLE
automated: linux: ltp: drop unsupported kirk flags

### DIFF
--- a/automated/linux/ltp/ltp.sh
+++ b/automated/linux/ltp/ltp.sh
@@ -196,8 +196,9 @@ run_ltp() {
     if [ "${KIRK_WORKERS}" = "max" ]; then
       KIRK_WORKERS=$(grep ^processor /proc/cpuinfo | wc -l)
     fi
-    pipe0_status "${RUNNER} ${EXTRA_KIRK_ARGS} --framework ltp --run-suite shardfile \
-                            -d ${LTP_TMPDIR} --env LTP_COLORIZE_OUTPUT=0 \
+    export LTP_COLORIZE_OUTPUT=0
+    pipe0_status "${RUNNER} ${EXTRA_KIRK_ARGS} --run-suite shardfile \
+                            -d ${LTP_TMPDIR} \
                             ${SKIPFILE_PATH:+--skip-file} ${SKIPFILE_PATH} \
                             ${KIRK_WORKERS:+--workers} ${KIRK_WORKERS} \
                             --no-colors \


### PR DESCRIPTION
ltp.sh passes --framework ltp and --env LTP_COLORIZE_OUTPUT=0 to kirk. Current kirk does not have these flags. kirk v4.1.0 rejects them and stops before any test runs.

Drop --framework. Set LTP_COLORIZE_OUTPUT in the shell before the kirk call instead of passing it with --env.