### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directories:
+      - "/**/*"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: pip
+    directories:
+      - "/**/*"
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
Track updates for the GitHub Actions used by the workflows, the base images in the Dockerfiles under test/ and automated/linux/, and the pip requirements files.

Action updates are grouped into a single pull request; pip runs monthly since the requirements are unpinned and rarely need attention.